### PR TITLE
bump starlette from 0.37.2 to 0.41.3

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-starlette = {extras = ["jinja2"], version = "==0.37.2"}
+starlette = {version = "==0.41.3", extras = ["jinja2"]}
 jinja2 = "3.1.4"
 mangum = "==0.17.0"
 httpx = "0.27.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "337472a7831b22fd39cd924ac2ebae037ba763c4f6f6de99dbac261583184997"
+            "sha256": "78bc92bc4fdb86380397dcf24c1b0eaab25ace8062711ef65019b4233ff9693c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,11 +18,11 @@
     "default": {
         "anyio": {
             "hashes": [
-                "sha256:5aadc6a1bbb7cdb0bede386cac5e2940f5e2ff3aa20277e991cf028e0585ce94",
-                "sha256:c1b2d8f46a8a812513012e1107cb0e68c17159a7a594208005a57dc776e1bdc7"
+                "sha256:4c8bc31ccdb51c7f7bd251f51c609e038d63e34219b44aa86e47576389880b4c",
+                "sha256:6d170c36fba3bdd840c73d3868c1e777e33676a69c3a72cf0a0d5d6d8009b61d"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==4.4.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==4.6.2.post1"
         },
         "babel": {
             "hashes": [
@@ -104,11 +104,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc",
-                "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
+                "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
+                "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==3.7"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.10"
         },
         "jinja2": {
             "hashes": [
@@ -402,11 +402,11 @@
                 "jinja2"
             ],
             "hashes": [
-                "sha256:6fe59f29268538e5d0d182f2791a479a0c64638e6935d1c6989e63fb2699c6ee",
-                "sha256:9af890290133b79fc3db55474ade20f6220a364a0402e0b556e7cd5e1e093823"
+                "sha256:0e4ab3d16522a255be6b28260b938eae2482f98ce5cc934cb08dce8dc3ba5835",
+                "sha256:44cedb2b7c77a9de33a8b74b2b90e9f50d11fcf25d8270ea525ad71a25374ff7"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==0.37.2"
+            "index": "pypi",
+            "version": "==0.41.3"
         },
         "starlette-babel": {
             "hashes": [


### PR DESCRIPTION
This PR bumps starlette from 0.37.2 to 0.41.3 because of a [vulnerability](https://github.com/encode/starlette/security/advisories/GHSA-f96h-pmfr-66vw) in versions <0.4.0.

tests are passing and I started the local server with no issues. Not sure if I need to check anything else.