### PR TITLE
remove can_register_vac variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v2-dependencies-{{ checksum "Pipfile.lock" }}
+            - v3-dependencies-{{ checksum "Pipfile.lock" }}
       - run: &install-pipenv pip install -U pipenv pip --quiet --no-input
       - run: pipenv sync --dev
       - run: pipenv run pipenv check # before save_cache so an insecure cache is never saved
@@ -25,7 +25,7 @@ jobs:
           when: on_success
           paths:
             - ~/.local/share/virtualenvs/
-          key: v2-dependencies-{{ checksum "Pipfile.lock" }}
+          key: v3-dependencies-{{ checksum "Pipfile.lock" }}
 
   test:
     docker:
@@ -39,7 +39,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v2-dependencies-{{ checksum "Pipfile.lock" }}
+            - v3-dependencies-{{ checksum "Pipfile.lock" }}
       - run: *install-pipenv
       - run: pipenv run ruff check .
       - run: pipenv run ruff format . --check
@@ -88,7 +88,7 @@ jobs:
           at: ~/repo/
       - restore_cache:
           keys:
-            - v2-dependencies-{{ checksum "Pipfile.lock" }}
+            - v3-dependencies-{{ checksum "Pipfile.lock" }}
       - run: *install-pipenv
       - run: pip install aws-sam-cli
 
@@ -122,7 +122,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v2-dependencies-{{ checksum "Pipfile.lock" }}
+            - v3-dependencies-{{ checksum "Pipfile.lock" }}
       - run: *install-pipenv
       - aws-cli/setup
       - run:
@@ -159,7 +159,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v2-dependencies-{{ checksum "Pipfile.lock" }}
+            - v3-dependencies-{{ checksum "Pipfile.lock" }}
       - run: *install-pipenv
       - aws-cli/setup
       - run:

--- a/postcode_lookup/template_sorter.py
+++ b/postcode_lookup/template_sorter.py
@@ -148,9 +148,6 @@ class RegistrationDateSection(BaseSection):
         context["can_register_postal_vote"] = self.timetable.is_before(
             TimetableEvent.POSTAL_VOTE_APPLICATION_DEADLINE
         )
-        context["can_register_vac"] = self.timetable.is_before(
-            TimetableEvent.VAC_APPLICATION_DEADLINE
-        )
         context["htag_primary"] = "h2"
         context["htag_secondary"] = "h3"
         if self.response_type == ResponseTypes.MULTIPLE_DATES:

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -413,8 +413,7 @@ def test_vac_application_deadline(
     template_sorter, election_date_template_sorter
 ):
     """this tests is after vac application deadline.
-    test that the page shows the vac application advice at the
-    top of the page and upcoming elections
+    test that the page shows upcoming elections
     and polling station if available next.
     assert that registration and postal vote deadline and
     candidates are not shown.


### PR DESCRIPTION
Refs https://app.asana.com/0/1204880927741389/1208687275764620/f

I was going through our code to see if there is anywhere we are presenting the VAC application deadline with a view to making sure we only show it in relevant situations (due to https://github.com/DemocracyClub/uk-election-timetables/issues/47 )

My conclusion from looking at this repo is that we never present this information. We set this `can_register_vac` variable, but then it is never referenced in any template. Maybe we intended to at some point. Lets delete this and we'll come back to it if we ever decide to implement this.