### PR TITLE
Fix/basic auth deploy

### DIFF
--- a/.circleci/tests/test_against_fqdn.py
+++ b/.circleci/tests/test_against_fqdn.py
@@ -9,7 +9,17 @@ STATIC_PAGE_COMMENT = "<!-- Static page content -->"
 
 
 def make_request(url):
-    req = httpx.get(url, timeout=20)
+    dc_env = os.environ.get("DC_ENVIRONMENT")
+
+    if dc_env == "development" or dc_env == "staging":
+        req = httpx.get(
+            url,
+            timeout=20,
+            auth=("dc", "dc"),
+        )
+    else:
+        req = httpx.get(url, timeout=20)
+
     req.raise_for_status()
     return req
 

--- a/template.yaml
+++ b/template.yaml
@@ -286,7 +286,14 @@ Resources:
             TargetOriginId: Dynamic
             Compress: true
             ViewerProtocolPolicy: "redirect-to-https"
-            CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+            ForwardedValues:
+              QueryString: true
+              Cookies:
+                Forward: none
+              Headers:
+                - Authorization
+                - Origin
+            MinTTL: '50'
           - AllowedMethods: [ GET, HEAD, OPTIONS ]
             PathPattern: /i-am-a/voter/your-election-information
             TargetOriginId: StaticPagesOriginGroup


### PR DESCRIPTION
I missed a few things in the previous deploy. Namely, the smoke tests didn't pass an auth header in dev and stage environments so the previous deploy failed. Also the static/* cache policy didn't allow auth headers so I've fixed that too.

Tested  by [deploying to staging](https://app.circleci.com/pipelines/github/DemocracyClub/ec-postcode-lookup-pages/485/workflows/bc1c4965-68aa-42d4-b648-646f4567dc78)