### PR TITLE
use git tag instead of git ref for dc-response-builder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dev = [
 package = false
 
 [tool.uv.sources]
-dc-response-builder = { git = "https://github.com/DemocracyClub/dc_response_builder.git", rev = "1.0.0" }
+dc-response-builder = { git = "https://github.com/DemocracyClub/dc_response_builder.git", tag = "1.0.0" }
 
 [tool.ruff]
 line-length = 80

--- a/uv.lock
+++ b/uv.lock
@@ -92,7 +92,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -144,7 +144,7 @@ wheels = [
 [[package]]
 name = "dc-response-builder"
 version = "1.0.0"
-source = { git = "https://github.com/DemocracyClub/dc_response_builder.git?rev=1.0.0#e048b421d79057fd3fcb36e722e5373987e4cdaa" }
+source = { git = "https://github.com/DemocracyClub/dc_response_builder.git?tag=1.0.0#e048b421d79057fd3fcb36e722e5373987e4cdaa" }
 dependencies = [
     { name = "pydantic", extra = ["email"] },
     { name = "uk-election-ids" },
@@ -218,7 +218,7 @@ dev = [
 requires-dist = [
     { name = "babel", specifier = "==2.15.0" },
     { name = "dateparser", specifier = "==1.2.0" },
-    { name = "dc-response-builder", git = "https://github.com/DemocracyClub/dc_response_builder.git?rev=1.0.0" },
+    { name = "dc-response-builder", git = "https://github.com/DemocracyClub/dc_response_builder.git?tag=1.0.0" },
     { name = "httpx", specifier = "==0.27.0" },
     { name = "jinja2", specifier = "==3.1.4" },
     { name = "mangum", specifier = "==0.17.0" },
@@ -983,7 +983,7 @@ name = "tzlocal"
 version = "5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzdata", marker = "platform_system == 'Windows'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/d3/c19d65ae67636fe63953b20c2e4a8ced4497ea232c43ff8d01db16de8dc0/tzlocal-5.2.tar.gz", hash = "sha256:8d399205578f1a9342816409cc1e46a93ebd5755e39ea2d85334bea911bf0e6e", size = 30201 }
 wheels = [


### PR DESCRIPTION
This is quite a small change, but it is related to how we will use renovate.
VCS packages with a `tag=` will be bumped to the latest tag
like this https://github.com/DemocracyClub/EveryElection/pull/2382
whereas if we use `rev=` them renovate will bump them to the latest commit
like this https://github.com/DemocracyClub/EveryElection/pull/2380
which is less helpful.

Also, side note: For compatibility with renovate, `tool.uv.sources` is the best way to work with VCS dependencies :+1: