### PR TITLE
render whitespace in cancelled election details

### DIFF
--- a/postcode_lookup/templates/includes/cancellation_reasons.html
+++ b/postcode_lookup/templates/includes/cancellation_reasons.html
@@ -52,7 +52,7 @@
         <h4>{{ ballot.metadata.cancelled_election.title }}</h4>
     {% endif %}
     {% if ballot.metadata.cancelled_election.detail %}
-        <p>{{ ballot.metadata.cancelled_election.detail }}</p>
+        <p>{{ ballot.metadata.cancelled_election.detail | nl2br }}</p>
     {% endif %}
     {% if ballot.metadata.cancelled_election.url %}
         <p><a href="{{ ballot.metadata.cancelled_election.url }}">Read more</a></p>

--- a/postcode_lookup/utils.py
+++ b/postcode_lookup/utils.py
@@ -9,6 +9,7 @@ import jinja2
 from babel.support import Translations
 from jinja2 import ChainableUndefined
 from jinja2.filters import do_mark_safe
+from markupsafe import Markup, escape
 from starlette.datastructures import URL, Headers
 from starlette.requests import Request
 from starlette.templating import Jinja2Templates
@@ -35,6 +36,10 @@ def date_format(value):
     date_obj = value if isinstance(value, date) else dateparser.parse(value)
     format = "EEEE dd MMMM y"
     return babel.dates.format_datetime(date_obj, format, locale=get_locale())
+
+
+def nl2br(value):
+    return Markup("<br>\n".join([escape(line) for line in value.splitlines()]))
 
 
 def translated_url(request: Request, name: str) -> URL:
@@ -143,6 +148,7 @@ class _i18nJinja2Templates(Jinja2Templates):
         env.filters["date_filter"] = date_format
         env.filters["apnumber"] = apnumber
         env.filters["pluralize"] = pluralize
+        env.filters["nl2br"] = nl2br
         env.policies["ext.i18n.trimmed"] = True
         env.globals["translated_url"] = translated_url
         env.globals["additional_ballot_link"] = additional_ballot_link

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,19 @@
+import pytest
+from utils import nl2br
+
+nl2br_testcases = [
+    ["abc", "abc"],
+    ["abc\ndef", "abc<br>\ndef"],
+    ["abc\r\ndef", "abc<br>\ndef"],
+    ["abc\n\ndef", "abc<br>\n<br>\ndef"],
+    [
+        '<script>alert("xss")</script>',
+        "&lt;script&gt;alert(&#34;xss&#34;)&lt;/script&gt;",
+    ],
+]
+
+
+@pytest.mark.parametrize("testcase", nl2br_testcases)
+def test_nl2br(testcase):
+    input_, expected = testcase
+    assert nl2br(input_) == expected


### PR DESCRIPTION
Refs https://app.asana.com/0/1209332771640377/1209332771640386/f

I've already edited the descriptions in EE to already include line breaks in the right places.

Just a small change here. In jinja we don't have a built-in newline to `<br/>` filter.
I've adopted the same approach as the widget here and used `white-space: pre-wrap;`

The terminology around cancelled/postponed is already all correct in this repo.