### PR TITLE
Deal with cancelled ballots better

### DIFF
--- a/postcode_lookup/endpoints.py
+++ b/postcode_lookup/endpoints.py
@@ -25,7 +25,7 @@ from utils import get_loader
 
 async def base_postcode_form(request: Request, backend: BaseAPIClient = None):
     return get_loader(request).TemplateResponse(
-        "index.html", {"request": request, "url_prefix": backend.URL_PREFIX}
+        request, "index.html", context={"url_prefix": backend.URL_PREFIX}
     )
 
 
@@ -89,7 +89,9 @@ async def base_postcode_endpoint(
     if context["api_response"].address_picker:
         template_name = "address_picker.html"
 
-    return get_loader(request).TemplateResponse(template_name, context)
+    return get_loader(request).TemplateResponse(
+        request, template_name, context=context
+    )
 
 
 # Use functools.partial to create a view function per backend
@@ -134,7 +136,9 @@ async def base_uprn_endpoint(request: Request, backend=None):
     template_name = template_sorter.main_template_name
     if context["api_response"].address_picker:
         template_name = "address_picker.html"
-    return get_loader(request).TemplateResponse(template_name, context)
+    return get_loader(request).TemplateResponse(
+        request, template_name, context=context
+    )
 
 
 live_uprn_view = functools.partial(base_uprn_endpoint, backend=LiveAPIBackend)
@@ -147,7 +151,6 @@ def results_context(api_response, request, postcode, backend):
     api_json = api_response
     context = {}
     context["api_response"] = RootModel.from_api_response(api_json)
-    context["request"] = request
     context["postcode"] = postcode
     context["uprn"] = request.path_params.get("uprn", None)
     context["url_prefix"] = backend.URL_PREFIX
@@ -196,9 +199,9 @@ async def redirect_root_to_postcode_form(request: Request):
     ballot_stages = get_ballot_stages(poll_open_date)
 
     return get_loader(request).TemplateResponse(
+        request,
         "debug_page.html",
-        {
-            "request": request,
+        context={
             "sandbox_postcodes": SANDBOX_POSTCODES,
             "mock_postcodes": example_responses,
             "ballot_stages": ballot_stages,
@@ -222,9 +225,9 @@ async def section_tester(request: Request):
                 cancellation_reason
             ).build()
             template = get_loader(request).TemplateResponse(
+                request,
                 "includes/cancellation_reasons.html",
-                {
-                    "request": request,
+                context={
                     "initial_poll_date": ballot.poll_open_date,
                     "ballot": ballot,
                 },
@@ -240,9 +243,9 @@ async def section_tester(request: Request):
             )
 
     return get_loader(request).TemplateResponse(
+        request,
         template_name,
-        {
-            "request": request,
+        context={
             "sections": sections,
         },
     )
@@ -250,8 +253,6 @@ async def section_tester(request: Request):
 
 async def design_system_view(request: Request):
     return get_loader(request).TemplateResponse(
+        request,
         "design_system.html",
-        {
-            "request": request,
-        },
     )

--- a/postcode_lookup/template_sorter.py
+++ b/postcode_lookup/template_sorter.py
@@ -212,6 +212,9 @@ class ElectionDateTemplateSorter:
         self.date_data = date_data
         self.first_upcoming_date = first_upcoming_date
         self.ballot_count = len(self.date_data.ballots)
+        self.uncancelled_ballot_count = len(
+            [b for b in self.date_data.ballots if not b.cancelled]
+        )
 
         self.all_cancelled = all(
             ballot.cancelled for ballot in self.date_data.ballots

--- a/postcode_lookup/template_sorter.py
+++ b/postcode_lookup/template_sorter.py
@@ -439,7 +439,7 @@ class TemplateSorter:
                         title = ballot.ballot_title
                         if ballot.cancelled:
                             title = (
-                                f"{title} {ballot_cancellation_suffix(ballot)}"
+                                f"{title}{ballot_cancellation_suffix(ballot)}"
                             )
                         toc.append(
                             {

--- a/postcode_lookup/template_sorter.py
+++ b/postcode_lookup/template_sorter.py
@@ -10,7 +10,7 @@ from starlette_babel import gettext_lazy as _
 from uk_election_timetables.calendars import Country
 from uk_election_timetables.election import TimetableEvent
 from uk_election_timetables.election_ids import from_election_id
-from utils import date_format
+from utils import ballot_cancellation_suffix, date_format
 
 # TODO: These might not be right! Implement in uk-election-timetables
 #  and think about them harder
@@ -436,9 +436,14 @@ class TemplateSorter:
             for section in self.dates[0].sections:
                 if isinstance(section, BallotSection):
                     for ballot in section.data.ballots:
+                        title = ballot.ballot_title
+                        if ballot.cancelled:
+                            title = (
+                                f"{title} {ballot_cancellation_suffix(ballot)}"
+                            )
                         toc.append(
                             {
-                                "label": ballot.ballot_title,
+                                "label": title,
                                 "anchor": ballot.ballot_paper_id,
                             }
                         )

--- a/postcode_lookup/templates/includes/cancellation_reasons.html
+++ b/postcode_lookup/templates/includes/cancellation_reasons.html
@@ -1,4 +1,4 @@
-<h3 id="{{ ballot.ballot_paper_id }}">{{ ballot.ballot_title }}</h3>
+<h3 id="{{ ballot.ballot_paper_id }}">{{ ballot.ballot_title }} {{ ballot|ballot_cancellation_suffix }}</h3>
 {% if ballot.cancellation_reason.name == "CANDIDATE_DEATH" %}
     <h4>{% trans %}Postponed Election{% endtrans %}</h4>
     <p>

--- a/postcode_lookup/templates/includes/cancellation_reasons.html
+++ b/postcode_lookup/templates/includes/cancellation_reasons.html
@@ -1,4 +1,4 @@
-<h3 id="{{ ballot.ballot_paper_id }}">{{ ballot.ballot_title }} {{ ballot|ballot_cancellation_suffix }}</h3>
+<h3 id="{{ ballot.ballot_paper_id }}">{{ ballot.ballot_title }}{{ ballot|ballot_cancellation_suffix }}</h3>
 {% if ballot.cancellation_reason.name == "CANDIDATE_DEATH" %}
     <h4>{% trans %}Postponed Election{% endtrans %}</h4>
     <p>

--- a/postcode_lookup/templates/includes/single_date.html
+++ b/postcode_lookup/templates/includes/single_date.html
@@ -6,13 +6,13 @@
 
 {% if date.uncancelled_ballot_count > 1 %}
     <p>
-        {% trans count=date.date_data.uncancelled_ballot_count %}
+        {% trans count=date.uncancelled_ballot_count %}
             You will have {{ count }} ballot papers to fill out:
         {% endtrans %}
     </p>
     <ul>
         {% for ballot in date.date_data.ballots %}
-            <li>{{ ballot.ballot_title }}</li>
+            <li>{{ ballot.ballot_title }} {{ ballot|ballot_cancellation_suffix }}</li>
         {% endfor %}
     </ul>
 {% endif %}

--- a/postcode_lookup/templates/includes/single_date.html
+++ b/postcode_lookup/templates/includes/single_date.html
@@ -4,9 +4,9 @@
     {% endif %}
 </h2>
 
-{% if date.date_data.ballots|length > 1 %}
+{% if date.uncancelled_ballot_count > 1 %}
     <p>
-        {% trans count=date.date_data.ballots|length %}
+        {% trans count=date.date_data.uncancelled_ballot_count %}
             You will have {{ count }} ballot papers to fill out:
         {% endtrans %}
     </p>

--- a/postcode_lookup/templates/includes/single_date.html
+++ b/postcode_lookup/templates/includes/single_date.html
@@ -15,6 +15,10 @@
             <li>{{ ballot.ballot_title }}{{ ballot|ballot_cancellation_suffix }}</li>
         {% endfor %}
     </ul>
+{% else %}
+    {% trans count=date.uncancelled_ballot_count %}
+        You will have one ballot paper to fill out.
+    {% endtrans %}
 {% endif %}
 
 

--- a/postcode_lookup/templates/includes/single_date.html
+++ b/postcode_lookup/templates/includes/single_date.html
@@ -12,7 +12,7 @@
     </p>
     <ul>
         {% for ballot in date.date_data.ballots %}
-            <li>{{ ballot.ballot_title }} {{ ballot|ballot_cancellation_suffix }}</li>
+            <li>{{ ballot.ballot_title }}{{ ballot|ballot_cancellation_suffix }}</li>
         {% endfor %}
     </ul>
 {% endif %}

--- a/postcode_lookup/utils.py
+++ b/postcode_lookup/utils.py
@@ -144,17 +144,17 @@ def ballot_cancellation_suffix(ballot: Ballot) -> str:
     if not ballot.cancellation_reason:
         # We don't really know what's going on here
         # so let's assume it's postponed.
-        return _("(postponed)")
+        return _(" (postponed)")
 
     if ballot.cancellation_reason in [
         CancellationReason.NO_CANDIDATES,
         CancellationReason.CANDIDATE_DEATH,
         CancellationReason.UNDER_CONTESTED,
     ]:
-        return _("(postponed)")
+        return _(" (postponed)")
 
     if ballot.cancellation_reason == CancellationReason.EQUAL_CANDIDATES:
-        return _("(uncontested)")
+        return _(" (uncontested)")
 
     # If we've got here we don't really know what's going on. Return nothing
     # to be safe.

--- a/postcode_lookup/utils.py
+++ b/postcode_lookup/utils.py
@@ -146,19 +146,27 @@ def ballot_cancellation_suffix(ballot: Ballot) -> str:
         # so let's assume it's postponed.
         return _(" (postponed)")
 
-    if ballot.cancellation_reason in [
-        CancellationReason.NO_CANDIDATES,
-        CancellationReason.CANDIDATE_DEATH,
-        CancellationReason.UNDER_CONTESTED,
-    ]:
+    if is_postponed(ballot.cancellation_reason):
         return _(" (postponed)")
 
-    if ballot.cancellation_reason == CancellationReason.EQUAL_CANDIDATES:
+    if is_uncontested(ballot.cancellation_reason):
         return _(" (uncontested)")
 
     # If we've got here we don't really know what's going on. Return nothing
     # to be safe.
     return ""
+
+
+def is_postponed(cancellation_reason: CancellationReason) -> bool:
+    return cancellation_reason in [
+        CancellationReason.NO_CANDIDATES,
+        CancellationReason.CANDIDATE_DEATH,
+        CancellationReason.UNDER_CONTESTED,
+    ]
+
+
+def is_uncontested(cancellation_reason: CancellationReason) -> bool:
+    return cancellation_reason == CancellationReason.EQUAL_CANDIDATES
 
 
 class _i18nJinja2Templates(Jinja2Templates):


### PR DESCRIPTION
This deals with a bug with a mix of cancelled and non-cancelled elections on the same day. 

Previous we would say "you will have N ballots to fill out", where the N would include the cancelled ballots. 

This change filters out the cancelled ballots before telling users how many ballots they will have. 