### PR TITLE
Feat/better error messaging

### DIFF
--- a/postcode_lookup/dc_api_client.py
+++ b/postcode_lookup/dc_api_client.py
@@ -17,6 +17,12 @@ class InvalidPostcodeException(Exception): ...
 class InvalidUPRNException(Exception): ...
 
 
+class ApiError(Exception):
+    """
+    Custom exception class to represent errors encountered while interacting with the API.
+    """
+
+
 def valid_postcode(postcode: str):
     postcode = str(postcode)[:10]
     if not postcode:
@@ -69,6 +75,8 @@ class BaseAPIClient(ABC):
         params.update(self.default_params)
         url = urljoin(self.get_base_url, endpoint)
         req = httpx.get(url, params=params)
+        if req.status_code == 400:
+            raise InvalidPostcodeException
         req.raise_for_status()
         return req
 
@@ -89,7 +97,7 @@ class LiveAPIBackend(BaseAPIClient):
             try:
                 return self._get(endpoint=f"postcode/{postcode}/").json()
             except httpx.HTTPError:
-                raise InvalidPostcodeException
+                raise ApiError
         raise InvalidPostcodeException
 
     def get_uprn(self, uprn: str) -> dict:

--- a/postcode_lookup/dc_api_client.py
+++ b/postcode_lookup/dc_api_client.py
@@ -75,8 +75,10 @@ class BaseAPIClient(ABC):
         params.update(self.default_params)
         url = urljoin(self.get_base_url, endpoint)
         req = httpx.get(url, params=params)
-        if req.status_code == 400:
+        if endpoint.startswith("postcode/") and req.status_code == 400:
             raise InvalidPostcodeException
+        if endpoint.startswith("address/") and req.status_code == 404:
+            raise InvalidUPRNException
         req.raise_for_status()
         return req
 
@@ -104,7 +106,7 @@ class LiveAPIBackend(BaseAPIClient):
         try:
             return self._get(endpoint=f"address/{uprn}/").json()
         except httpx.HTTPError:
-            raise InvalidUPRNException
+            raise ApiError
 
 
 class SandboxAPIBackend(BaseAPIClient):

--- a/postcode_lookup/endpoints.py
+++ b/postcode_lookup/endpoints.py
@@ -130,11 +130,12 @@ async def base_uprn_endpoint(request: Request, backend=None):
             api_key=os.environ.get("API_KEY", "ec-postcode-testing"),
             request=request,
         ).get_uprn(uprn)
-    except InvalidUPRNException:
+    except (InvalidUPRNException, ApiError) as e:
+        query_param = "api-error" if isinstance(e, ApiError) else "invalid-uprn"
         return RedirectResponse(
             request.url_for(
                 backend.URL_PREFIX + "_postcode_form_en"
-            ).include_query_params(**{"invalid-uprn": 1})
+            ).include_query_params(**{query_param: 1})
         )
     context = results_context(api_response, request, postcode, backend)
 

--- a/postcode_lookup/endpoints.py
+++ b/postcode_lookup/endpoints.py
@@ -78,9 +78,7 @@ async def base_postcode_endpoint(
         ).get_postcode(postcode)
     except (InvalidPostcodeException, ApiError) as e:
         query_param = (
-            "invalid-postcode"
-            if isinstance(e, InvalidPostcodeException)
-            else "api-error"
+            "api-error" if isinstance(e, ApiError) else "invalid-postcode"
         )
         return RedirectResponse(
             request.url_for(

--- a/postcode_lookup/templates/index.html
+++ b/postcode_lookup/templates/index.html
@@ -22,7 +22,7 @@
                         <label for="postcode-search">
                             {% trans %}Enter your postcode{% endtrans %}</label>
                         <p class="dc-form-hint">eg. SW1A 2AA</p>
-                        <p class="error_message">Please enter a valid UK postcode</p>
+                        <p id="postcode-search-error-message" class="error_message">Please enter a valid UK postcode</p>
                         <div class="dc-inline-form">
                             <input
                                     id="postcode-search"
@@ -64,12 +64,21 @@
                             return urlParams.get(param);
                         }
 
-                        const errorParam = getQueryParam('invalid-postcode');
-                        if (errorParam === '1') {
-                            // Display the error message
-                            document.getElementById('dc-postcode-search-form').classList.add("error");
-                            postcodeInput.setAttribute("aria-invalid", "true")
+                        // Function to handle error message display
+                        function handleErrorDisplay(param, message = null) {
+                            if (getQueryParam(param) === '1') {
+                                // display error message
+                                document.getElementById('dc-postcode-search-form').classList.add("error");
+                                postcodeInput.setAttribute("aria-invalid", "true");
+                                // optionally customize message text
+                                if (message) {
+                                    document.getElementById('postcode-search-error-message').innerHTML = message;
+                                }
+                            }
                         }
+
+                        handleErrorDisplay('invalid-postcode');
+                        handleErrorDisplay('api-error', "Sorry, there's a problem with this service at the moment. We're working to fix it as soon as possible.");
 
                         postcodeInput.addEventListener('input', function () {
                             if (postcodeInput.validity.valid) {

--- a/tests/test_dc_api_client.py
+++ b/tests/test_dc_api_client.py
@@ -86,6 +86,21 @@ def test_get_invalid_postcode_frontend(respx_mock, app_client):
     assert resp.next_request.url.query.decode() == "invalid-postcode=1"
 
 
+def test_api_error_frontend(respx_mock, app_client):
+    respx_mock.get(
+        "https://developers.democracyclub.org.uk/api/v1/postcode/SE228DJ/?auth_token=ec-postcode-testing&utm_source=ec_postcode_lookup&recall_petition=1"
+    ).mock(return_value=httpx.Response(500))
+
+    resp = app_client.get(
+        "/polling-stations",
+        params={"postcode-search": "SE228DJ"},
+        follow_redirects=False,
+    )
+
+    assert resp.status_code == 307
+    assert resp.next_request.url.query.decode() == "api-error=1"
+
+
 @pytest.mark.parametrize(
     "postcode,valid",
     [


### PR DESCRIPTION
This PR adds a custom ApiError class to represent errors outside of User control (e.g. Internal Server Errors on the API end, timeouts, connection issues) and adds a "We're sorry" message to the frontend when the ApiError is raised.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209908934314102