### PR TITLE
temp: filter out referenda before validation

### DIFF
--- a/postcode_lookup/endpoints.py
+++ b/postcode_lookup/endpoints.py
@@ -155,6 +155,18 @@ sandbox_uprn_view = functools.partial(
 
 def results_context(api_response, request, postcode, backend):
     api_json = api_response
+
+    # TODO: delete me
+    for i, date in enumerate(api_json.get("dates", [])):
+        if date.get("ballots"):
+            date["ballots"] = [
+                b
+                for b in date["ballots"]
+                if not b["ballot_paper_id"].startswith("ref")
+            ]
+            if len(date["ballots"]) == 0:
+                api_json["dates"].pop(i)
+
     context = {}
     context["api_response"] = RootModel.from_api_response(api_json)
     context["postcode"] = postcode


### PR DESCRIPTION
This PR temporarily bins referenda from the API response before we try to validate it.
This is just to buy us a bit of breathing space while we properly fix things.