### PR TITLE
update 'no upcoming elections' messaging

### DIFF
--- a/postcode_lookup/locale/cy/LC_MESSAGES/messages.po
+++ b/postcode_lookup/locale/cy/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: EC postcode pages\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-04-27 14:31+0100\n"
+"POT-Creation-Date: 2026-04-28 14:34+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: cy\n"
@@ -15,81 +15,81 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.16.0\n"
 
-#: postcode_lookup/template_sorter.py:106
-#: postcode_lookup/template_sorter.py:127
+#: postcode_lookup/template_sorter.py:105
+#: postcode_lookup/template_sorter.py:126
 msgid "Where to vote"
 msgstr "Ble i bleidleisio"
 
-#: postcode_lookup/template_sorter.py:261
+#: postcode_lookup/template_sorter.py:260
 #: postcode_lookup/templates/includes/postal_votes.html:1
 msgid "Voting by post"
 msgstr "Pleidleisio drwy'r post"
 
-#: postcode_lookup/template_sorter.py:296
-#: postcode_lookup/template_sorter.py:323
+#: postcode_lookup/template_sorter.py:295
+#: postcode_lookup/template_sorter.py:322
 #: postcode_lookup/templates/includes/registration_timetable.html:1
 #: postcode_lookup/templates/includes/registration_timetable_city_of_london.html:8
 msgid "Voter registration"
 msgstr "Cofrestru pleidleiswyr"
 
-#: postcode_lookup/template_sorter.py:369
+#: postcode_lookup/template_sorter.py:368
 msgid "7am – 10pm"
 msgstr "7am – 10pm"
 
-#: postcode_lookup/template_sorter.py:374
+#: postcode_lookup/template_sorter.py:373
 msgid "8am – 8pm"
 msgstr "8am – 8pm"
 
-#: postcode_lookup/template_sorter.py:392
+#: postcode_lookup/template_sorter.py:391
 msgid "There may also be parish or town council elections in some areas."
 msgstr "Efallai y bydd etholiadau cyngor plwyf neu dref mewn rhai ardaloedd hefyd."
 
-#: postcode_lookup/template_sorter.py:396
+#: postcode_lookup/template_sorter.py:395
 msgid "There may also be community council elections in some areas."
 msgstr "Efallai y bydd etholiadau cyngor cymuned mewn rhai ardaloedd hefyd."
 
-#: postcode_lookup/template_sorter.py:400
+#: postcode_lookup/template_sorter.py:399
 msgid "There may also be town or community council elections in some areas."
 msgstr ""
 "Mae'n bosib y bydd etholiadau cynghorau tref neu gymuned mewn rhai "
 "ardaloedd."
 
-#: postcode_lookup/template_sorter.py:587
+#: postcode_lookup/template_sorter.py:586
 msgid "There are no upcoming elections in your area"
 msgstr "Nid oes etholiadau ar y gweill yn eich ardal"
 
-#: postcode_lookup/template_sorter.py:593
+#: postcode_lookup/template_sorter.py:592
 msgid "Uncontested"
 msgstr "Heb gystadleuaeth"
 
-#: postcode_lookup/template_sorter.py:596
-#: postcode_lookup/template_sorter.py:601
+#: postcode_lookup/template_sorter.py:595
+#: postcode_lookup/template_sorter.py:600
 msgid "Postponed"
 msgstr "Wedi'i ohirio"
 
-#: postcode_lookup/template_sorter.py:611
+#: postcode_lookup/template_sorter.py:610
 msgid "You have an election today"
 msgstr "Mae gennych etholiad heddiw"
 
-#: postcode_lookup/template_sorter.py:614
+#: postcode_lookup/template_sorter.py:613
 msgid "You have an upcoming election"
 msgstr "Mae gennych etholiad sydd ar y gweill"
 
-#: postcode_lookup/template_sorter.py:617
-#: postcode_lookup/template_sorter.py:620
+#: postcode_lookup/template_sorter.py:616
+#: postcode_lookup/template_sorter.py:619
 msgid "You have upcoming elections"
 msgstr "Mae gennych etholiadau sydd ar y gweill"
 
-#: postcode_lookup/template_sorter.py:690
+#: postcode_lookup/template_sorter.py:689
 #: postcode_lookup/templates/includes/organisation_contact.html:36
 msgid "Your local council"
 msgstr "Eich cyngor lleol"
 
-#: postcode_lookup/template_sorter.py:697
+#: postcode_lookup/template_sorter.py:696
 msgid "Electoral registration"
 msgstr "Cofrestru etholiadol"
 
-#: postcode_lookup/template_sorter.py:703
+#: postcode_lookup/template_sorter.py:702
 #: postcode_lookup/templates/includes/organisation_contact.html:25
 msgid "Your returning officer"
 msgstr "Eich swyddog canlyniadau"
@@ -320,6 +320,26 @@ msgstr "Mewnbynnwch eich cod post i ganfod pwy yw’r ymgeiswyr yn eich ardal."
 #: postcode_lookup/templates/results.html:25
 msgid "On this page"
 msgstr "Ar y dudalen hon"
+
+#: postcode_lookup/templates/results_no_upcoming.html:6
+msgid "There are no scheduled elections in your area over the next 2 months."
+msgstr ""
+
+#: postcode_lookup/templates/results_no_upcoming.html:11
+msgid ""
+"Elections typically happen on the first Thursday in May. Please check "
+"back closer to the time."
+msgstr ""
+
+#: postcode_lookup/templates/results_no_upcoming.html:15
+msgid "/voting-and-elections/how-elections-work/types-elections"
+msgstr "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/mathau-o-etholiadau"
+
+#: postcode_lookup/templates/results_no_upcoming.html:18
+msgid ""
+"Find out about when different elections typically take place where you "
+"live."
+msgstr ""
 
 #: postcode_lookup/templates/includes/ballots.html:10
 msgid "parties and independent candidates"

--- a/postcode_lookup/locale/cy/LC_MESSAGES/messages.po
+++ b/postcode_lookup/locale/cy/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: EC postcode pages\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-23 13:11+0100\n"
+"POT-Creation-Date: 2026-07-07 11:52+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: cy\n"
@@ -15,81 +15,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.16.0\n"
 
-#: postcode_lookup/template_sorter.py:105
-#: postcode_lookup/template_sorter.py:141
+#: postcode_lookup/scheduled_elections.py:74
+msgid "The next scheduled elections in Scotland will take place on {date}"
+msgstr ""
+
+#: postcode_lookup/scheduled_elections.py:78
+msgid "The next scheduled elections in Wales will take place on {date}"
+msgstr ""
+
+#: postcode_lookup/scheduled_elections.py:82
+msgid "The next scheduled elections in Northern Ireland will take place on {date}"
+msgstr ""
+
+#: postcode_lookup/scheduled_elections.py:92
+msgid ""
+"The next UK General Election must be held no later than {date}, however "
+"the prime minister can choose to hold it at any point before this."
+msgstr ""
+
+#: postcode_lookup/template_sorter.py:109
+#: postcode_lookup/template_sorter.py:145
 msgid "Where to vote"
 msgstr "Ble i bleidleisio"
 
-#: postcode_lookup/template_sorter.py:280
+#: postcode_lookup/template_sorter.py:284
 #: postcode_lookup/templates/includes/postal_votes.html:1
 msgid "Voting by post"
 msgstr "Pleidleisio drwy'r post"
 
-#: postcode_lookup/template_sorter.py:315
-#: postcode_lookup/template_sorter.py:342
+#: postcode_lookup/template_sorter.py:319
+#: postcode_lookup/template_sorter.py:346
 #: postcode_lookup/templates/includes/registration_timetable.html:1
 #: postcode_lookup/templates/includes/registration_timetable_city_of_london.html:8
 msgid "Voter registration"
 msgstr "Cofrestru pleidleiswyr"
 
-#: postcode_lookup/template_sorter.py:389
+#: postcode_lookup/template_sorter.py:393
 msgid "7am – 10pm"
 msgstr "7am – 10pm"
 
-#: postcode_lookup/template_sorter.py:394
+#: postcode_lookup/template_sorter.py:398
 msgid "8am – 8pm"
 msgstr "8am – 8pm"
 
-#: postcode_lookup/template_sorter.py:412
+#: postcode_lookup/template_sorter.py:416
 msgid "There may also be parish or town council elections in some areas."
 msgstr "Efallai y bydd etholiadau cyngor plwyf neu dref mewn rhai ardaloedd hefyd."
 
-#: postcode_lookup/template_sorter.py:416
+#: postcode_lookup/template_sorter.py:420
 msgid "There may also be community council elections in some areas."
 msgstr "Efallai y bydd etholiadau cyngor cymuned mewn rhai ardaloedd hefyd."
 
-#: postcode_lookup/template_sorter.py:420
+#: postcode_lookup/template_sorter.py:424
 msgid "There may also be town or community council elections in some areas."
 msgstr ""
 "Mae'n bosib y bydd etholiadau cynghorau tref neu gymuned mewn rhai "
 "ardaloedd."
 
-#: postcode_lookup/template_sorter.py:611
-msgid "There are no upcoming elections in your area"
-msgstr "Nid oes etholiadau ar y gweill yn eich ardal"
+#: postcode_lookup/template_sorter.py:621
+#: postcode_lookup/template_sorter.py:656
+#: postcode_lookup/templates/index.html:5
+msgid "My next election"
+msgstr "Fy etholiad nesaf"
 
-#: postcode_lookup/template_sorter.py:617
+#: postcode_lookup/template_sorter.py:627
 msgid "Uncontested"
 msgstr "Heb gystadleuaeth"
 
-#: postcode_lookup/template_sorter.py:620
-#: postcode_lookup/template_sorter.py:625
+#: postcode_lookup/template_sorter.py:630
+#: postcode_lookup/template_sorter.py:635
 msgid "Postponed"
 msgstr "Wedi'i ohirio"
 
-#: postcode_lookup/template_sorter.py:635
+#: postcode_lookup/template_sorter.py:645
 msgid "You have an election today"
 msgstr "Mae gennych etholiad heddiw"
 
-#: postcode_lookup/template_sorter.py:638
+#: postcode_lookup/template_sorter.py:648
 msgid "You have an upcoming election"
 msgstr "Mae gennych etholiad sydd ar y gweill"
 
-#: postcode_lookup/template_sorter.py:641
-#: postcode_lookup/template_sorter.py:644
+#: postcode_lookup/template_sorter.py:651
+#: postcode_lookup/template_sorter.py:654
 msgid "You have upcoming elections"
 msgstr "Mae gennych etholiadau sydd ar y gweill"
 
-#: postcode_lookup/template_sorter.py:714
+#: postcode_lookup/template_sorter.py:724
 #: postcode_lookup/templates/includes/organisation_contact.html:36
 msgid "Your local council"
 msgstr "Eich cyngor lleol"
 
-#: postcode_lookup/template_sorter.py:721
+#: postcode_lookup/template_sorter.py:731
 msgid "Electoral registration"
 msgstr "Cofrestru etholiadol"
 
-#: postcode_lookup/template_sorter.py:727
+#: postcode_lookup/template_sorter.py:737
 #: postcode_lookup/templates/includes/organisation_contact.html:25
 msgid "Your returning officer"
 msgstr "Eich swyddog canlyniadau"
@@ -246,10 +266,6 @@ msgstr "Eisiau darganfod pryd mae’ch etholiad nesaf? Defnyddiwch ein teclyn."
 msgid "Elections in my area"
 msgstr "Etholiadau yn fy ardal"
 
-#: postcode_lookup/templates/index.html:5
-msgid "My next election"
-msgstr "Fy etholiad nesaf"
-
 #: postcode_lookup/templates/index.html:17
 msgid ""
 "Enter your postcode to find out about voting in your next election. We'll"
@@ -323,6 +339,26 @@ msgstr "Mewnbynnwch eich cod post i ganfod pwy yw’r ymgeiswyr yn eich ardal."
 #: postcode_lookup/templates/results.html:25
 msgid "On this page"
 msgstr "Ar y dudalen hon"
+
+#: postcode_lookup/templates/results_no_upcoming.html:12
+msgid "Scheduled elections typically happen on the first Thursday in May."
+msgstr ""
+
+#: postcode_lookup/templates/results_no_upcoming.html:25
+msgid "By-elections can be called at any time."
+msgstr ""
+
+#: postcode_lookup/templates/results_no_upcoming.html:31
+msgid "/voting-and-elections/how-elections-work/types-elections"
+msgstr ""
+"/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-"
+"gweithio/mathau-o-etholiadau"
+
+#: postcode_lookup/templates/results_no_upcoming.html:34
+msgid ""
+"Find out about when different elections typically take place where you "
+"live."
+msgstr ""
 
 #: postcode_lookup/templates/includes/ballots.html:9
 msgid "parties and independent candidates"

--- a/postcode_lookup/scheduled_elections.py
+++ b/postcode_lookup/scheduled_elections.py
@@ -1,0 +1,95 @@
+import datetime as dt
+
+from starlette_babel import gettext_lazy as _
+from uk_election_timetables.calendars import Country
+from utils import date_format
+
+"""
+Rough calendar of known upcoming scheduled election dates
+where those are easy to express at a very high level.
+This won't need updating super often
+but it will go stale at some point.
+
+Note: It might be tempting to add "London" in here but
+1. City of London Corporation has its own wierd schedule
+2. There are a number of authorities inside London with local authority mayors:
+    - Croydon
+    - Hackney
+    - Lewisham
+    - Newham
+    - Tower Hamlets
+..which is enough edge cases that it is
+not sensible to try and generalse about London here.
+"""
+KNOWN_SCHEDULED_ELECTIONS = {
+    Country.SCOTLAND: [
+        dt.date(2027, 5, 6),  # Local Councils
+        dt.date(2031, 5, 1),  # Scottish Parliament
+    ],
+    Country.WALES: [
+        dt.date(2027, 5, 6),  # Local Councils
+        dt.date(2031, 5, 1),  # Senedd
+    ],
+    Country.NORTHERN_IRELAND: [
+        dt.date(2027, 5, 6),  # Local Councils and NI Assembly
+        dt.date(2031, 5, 1),  # Local Councils
+    ],
+    Country.ENGLAND: [],  # its complicated
+}
+
+
+def get_next_scheduled_election_date(country):
+    try:
+        elections = KNOWN_SCHEDULED_ELECTIONS[country]
+    except KeyError:
+        return None
+
+    now = dt.date.today()
+    for election_date in elections:
+        if election_date > now:
+            return election_date
+    return None
+
+
+def get_next_scheduled_election_block(country):
+    date = get_next_scheduled_election_date(country)
+    if country == Country.ENGLAND or not date:
+        return None
+
+    """
+    Note: This is a bit clunky,
+    but this is a sentence where we can't get away with
+
+    "The next scheduled elections in {country} will take place on {date}"
+
+    because of mutations
+    "Wales" --> "Cymru"
+    but
+    "in Wales" --> "yng Nghymru"
+
+    so we need a bit of duplication to allow
+    translators to work with the text in context
+    """
+    if country == Country.SCOTLAND:
+        return _(
+            "The next scheduled elections in Scotland will take place on {date}"
+        ).format(date=date_format(date))
+    if country == Country.WALES:
+        return _(
+            "The next scheduled elections in Wales will take place on {date}"
+        ).format(date=date_format(date))
+    if country == Country.NORTHERN_IRELAND:
+        return _(
+            "The next scheduled elections in Northern Ireland will take place on {date}"
+        ).format(date=date_format(date))
+
+    return None
+
+
+def get_next_general_election_block():
+    next_ge_date = dt.date(2029, 8, 15)
+    if dt.datetime.now().date() < dt.date(2029, 7, 12):
+        return _(
+            "The next UK General Election must be held no later than {date}, however the prime minister can choose to hold it at any point before this."
+        ).format(date=date_format(next_ge_date))
+    return None

--- a/postcode_lookup/template_sorter.py
+++ b/postcode_lookup/template_sorter.py
@@ -7,6 +7,10 @@ from typing import Dict, List, Optional
 from dateparser import parse
 from postal_votes import get_postal_vote_dispatch_dates
 from response_builder.v1.models.base import Date, RootModel
+from scheduled_elections import (
+    get_next_general_election_block,
+    get_next_scheduled_election_block,
+)
 from starlette_babel import gettext_lazy as _
 from uk_election_timetables.calendars import Country
 from uk_election_timetables.election import TimetableEvent
@@ -517,6 +521,24 @@ class TemplateSorter:
         self.electoral_registration = getattr(
             self.api_response, "registration", None
         )
+
+        if self.electoral_services:
+            self.country = country_map[self.electoral_services.nation]
+        else:
+            self.country = Country.ENGLAND
+
+        in_london = False
+        if self.electoral_services:
+            in_london = any(
+                id_.startswith("E09")
+                for id_ in self.electoral_services.identifiers
+            )
+
+        self.next_scheduled_election_block = get_next_scheduled_election_block(
+            self.country
+        )
+        self.next_general_election_block = get_next_general_election_block()
+
         for i, date in enumerate(self.api_response.dates):
             postal_vote_dispatch_dates = None
             replacement_pack_start_date = None
@@ -528,7 +550,6 @@ class TemplateSorter:
                 and date.date == "2026-05-07"
             ):
                 show_dispatch_date_fallback = True
-                country = country_map[self.electoral_services.nation]
 
                 postal_vote_dispatch_dates = get_postal_vote_dispatch_dates(
                     self.electoral_services.council_id
@@ -537,7 +558,7 @@ class TemplateSorter:
                 # this is the date when replacement packs can be issued from
                 # for ALL councils
                 # TODO: add this to the timetable library
-                if country == Country.SCOTLAND:
+                if self.country == Country.SCOTLAND:
                     replacement_pack_start_date = None
                 else:
                     replacement_pack_start_date = datetime.datetime.strptime(
@@ -546,22 +567,11 @@ class TemplateSorter:
 
             if parse(date.date).date() < datetime.datetime.today().date():
                 continue
-            if self.electoral_services:
-                country = country_map[self.electoral_services.nation]
-            else:
-                country = Country.ENGLAND
-
-            in_london = False
-            if self.electoral_services:
-                in_london = any(
-                    id_.startswith("E09")
-                    for id_ in self.electoral_services.identifiers
-                )
 
             self.dates.append(
                 ElectionDateTemplateSorter(
                     date_data=date,
-                    country=country,
+                    country=self.country,
                     current_date=self.current_date,
                     response_type=self.response_type,
                     first_upcoming_date=not i > 0,
@@ -608,7 +618,7 @@ class TemplateSorter:
         :return:
         """
         if not self.dates:
-            return _("There are no upcoming elections in your area")
+            return _("My next election")
 
         if self.all_cancelled:
             cancellation_reasons = self.all_cancelled_reasons
@@ -643,7 +653,7 @@ class TemplateSorter:
         if self.response_type == ResponseTypes.MULTIPLE_DATES:
             return _("You have upcoming elections")
 
-        return "Elections in your areas"
+        return _("My next election")
 
     @cached_property
     def toc_items(self) -> Optional[List[Dict[str, str]]]:

--- a/postcode_lookup/templates/results_no_upcoming.html
+++ b/postcode_lookup/templates/results_no_upcoming.html
@@ -1,1 +1,29 @@
 {% extends 'results.html' %}
+
+{% block content %}
+    <div class="dc-container">
+        <p>
+          {% trans %}
+            There are no scheduled elections in your area over the next 2 months.
+          {% endtrans %}
+        </p>
+        <p>
+          {% trans %}
+            Elections typically happen on the first Thursday in May. Please check back closer to the time.
+          {% endtrans %}
+        <p>
+          {% with url=_("/voting-and-elections/how-elections-work/types-elections") %}
+            <a href="{{ url }}">
+          {% endwith %}
+            {% trans %}
+              Find out about when different elections typically take place where you live.
+            {% endtrans %}
+          </a>
+        </p>
+
+        {% include 'includes/contact_details.html' %}
+
+        {% include 'includes/feedback_section.html' %}
+
+    </div>
+{% endblock %}

--- a/postcode_lookup/templates/results_no_upcoming.html
+++ b/postcode_lookup/templates/results_no_upcoming.html
@@ -1,1 +1,45 @@
 {% extends 'results.html' %}
+
+{% block content %}
+    <div class="dc-container">
+
+        {% if template_sorter.next_scheduled_election_block %}
+          <p>
+            {{ template_sorter.next_scheduled_election_block }}
+          </p>
+        {% else %}
+          <p>
+            {% trans %}
+              Scheduled elections typically happen on the first Thursday in May.
+            {% endtrans %}
+          </p>
+        {% endif %}
+
+        {% if template_sorter.next_general_election_block %}
+          <p>
+            {{ template_sorter.next_general_election_block }}
+          </p>
+        {% endif %}
+
+        <p>
+          {% trans %}
+            By-elections can be called at any time.
+          {% endtrans %}
+        </p>
+
+        <p>
+          {% with url=_("/voting-and-elections/how-elections-work/types-elections") %}
+            <a href="{{ url }}">
+          {% endwith %}
+            {% trans %}
+              Find out about when different elections typically take place where you live.
+            {% endtrans %}
+          </a>
+        </p>
+
+        {% include 'includes/contact_details.html' %}
+
+        {% include 'includes/feedback_section.html' %}
+
+    </div>
+{% endblock %}

--- a/tests/test_dc_api_client.py
+++ b/tests/test_dc_api_client.py
@@ -58,7 +58,7 @@ def test_get_postcode_endpoint(respx_mock, app_client):
         follow_redirects=False,
     )
     assert resp.status_code == 200
-    assert "There are no upcoming elections in your area" in resp.text
+    assert "Your local council" in resp.text
 
 
 def test_get_invalid_postcode_api_client(respx_mock):


### PR DESCRIPTION
The point of this PR is to give the user more useful information about possible upcoming elections on the "we don't know of upcoming elections" page. Example outputs:

**Wales**
<img width="946" height="472" alt="Screenshot at 2026-07-07 12-09-34" src="https://github.com/user-attachments/assets/5a034578-253d-40b3-b617-f3de06d6e940" />

**England**
<img width="967" height="470" alt="Screenshot at 2026-07-07 12-09-44" src="https://github.com/user-attachments/assets/49306e05-e888-4339-99f4-c069aed7b765" />

Next step on this one is probably to get some feed back from the EC comms teams as I've freestyled this a bit based on our conversation last week.

This PR does introduce a bit of data that we have to maintain that may become stale or inaccurate over time, but I've tried to do this in a way that will not be too cumbersome and will "fail safe" as far as possible. More on this inline.