### PR TITLE
move polling stations to top one day before polling day

### DIFF
--- a/postcode_lookup/template_sorter.py
+++ b/postcode_lookup/template_sorter.py
@@ -93,7 +93,7 @@ class PollingStationSection(BaseSection):
     def weight(self):
         poll_date = parse(self.data.date).date()
 
-        days_before_poll = 3
+        days_before_poll = 1
         if (
             poll_date - datetime.timedelta(days=days_before_poll)
         ) < self.current_date:


### PR DESCRIPTION
Only move "Your polling station" above candidates on polling day itself and the day before

For the 3 areas with flex voting pilots, we'll stick with polling stations taking top billing from now to polling day