### PR TITLE
generate related content based on upcoming ballots

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,17 @@ This will update various front end assets in `postcode_lookup/static`.
 
 See [lib/template_generator/README.md](lib/template_generator/README.md) for
 more information about this script.
+
+# Updating pages mirror
+
+We mirror the page titles and descriptions (in English and Welsh)
+for a bunch of pages on the EC site to make it easy to link out to
+content elsewhere on the site.
+
+If we need to update this, run
+
+```shell
+uv run lib/pages_mirror/harvest.py
+```
+
+This will output `postcode_lookup/data/pages.json`.

--- a/lib/pages_mirror/harvest.py
+++ b/lib/pages_mirror/harvest.py
@@ -1,0 +1,107 @@
+import json
+import logging
+from pathlib import Path
+from time import sleep
+from urllib.parse import urlparse
+
+import bs4
+from wreq import Emulation
+from wreq.blocking import Client
+from wreq.redirect import Policy
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+URLS = [
+    "https://www.electoralcommission.org.uk/i-am-a/voter/register-vote-and-update-your-details",
+    "https://www.electoralcommission.org.uk/i-am-a/voter/apply-vote-post",
+    "https://www.electoralcommission.org.uk/i-am-a/voter/apply-vote-proxy",
+    "https://www.electoralcommission.org.uk/i-am-a/voter/voter-id",
+    "https://www.electoralcommission.org.uk/voting-and-elections/how-elections-work/types-elections/northern-ireland-assembly",
+    "https://www.electoralcommission.org.uk/voting-and-elections/how-elections-work/types-elections/voting-senedd-elections",
+    "https://www.electoralcommission.org.uk/voting-and-elections/how-elections-work/types-elections/scottish-parliament",
+    "https://www.electoralcommission.org.uk/voting-and-elections/how-elections-work/types-elections/police-and-crime-commissioners",
+    "https://www.electoralcommission.org.uk/voting-and-elections/how-elections-work/types-elections/mayoral-elections",
+    "https://www.electoralcommission.org.uk/voting-and-elections/how-elections-work/types-elections/mayor-london-and-london-assembly",
+    "https://www.electoralcommission.org.uk/voting-and-elections/how-elections-work/types-elections/uk-parliamentary-elections",
+    "https://www.electoralcommission.org.uk/voting-and-elections/how-elections-work/types-elections/uk-parliament",
+    "https://www.electoralcommission.org.uk/voting-and-elections/how-elections-work/types-elections/local-council-elections",
+    "https://www.electoralcommission.org.uk/voting-and-elections/how-elections-work/types-elections/local-councils",
+    "https://www.electoralcommission.org.uk/voting-and-elections/how-elections-work/types-elections",
+    "https://www.electoralcommission.org.uk/voting-and-elections",
+]
+
+
+client = Client(emulation=Emulation.Safari26)
+
+
+def _get(url):
+    # space out requests
+    sleep(5)
+
+    logger.info(f"Requesting {url} ...")
+    return client.get(url, redirect=Policy.limited())
+
+
+def extract_meta(soup: bs4.BeautifulSoup, url: str) -> dict:
+    path = urlparse(url).path
+
+    title_tag = soup.find("meta", property="og:title")
+    if not title_tag:
+        raise Exception(f"Failed to find og:title for {path}")
+
+    description_tag = soup.find("meta", property="og:description")
+    if not description_tag:
+        description_tag = title_tag
+        logger.error(
+            f"Error: Failed to find og:description for {path}, using og:title instead"
+        )
+
+    return {
+        "url": path,
+        "title": title_tag["content"] if title_tag else None,
+        "description": description_tag["content"] if description_tag else None,
+    }
+
+
+def harvest():
+    results = {}
+
+    for url in URLS:
+        en_path = urlparse(url).path
+
+        en_response = _get(url)
+        en_response.raise_for_status()
+        en_soup = bs4.BeautifulSoup(en_response.text(), "html.parser")
+
+        cy_link = en_soup.find("link", rel="alternate", hreflang="cy")
+        cy_url = cy_link["href"] if cy_link else None
+
+        if not cy_url:
+            raise Exception(f"Failed to find translated page for {en_path}")
+
+        cy_response = _get(cy_url)
+        en_response.raise_for_status()
+        cy_soup = bs4.BeautifulSoup(cy_response.text(), "html.parser")
+
+        results[en_path] = {
+            "en": extract_meta(en_soup, url),
+            "cy": extract_meta(cy_soup, cy_url),
+        }
+
+    outfile = (
+        Path(__file__).parent
+        / ".."
+        / ".."
+        / "postcode_lookup"
+        / "data"
+        / "pages.json"
+    )
+    with open(outfile, "w") as f:
+        json.dump(results, f, indent=2, ensure_ascii=False)
+
+    logger.info(f"Wrote {len(results)} pages to {outfile}")
+
+
+if __name__ == "__main__":
+    harvest()

--- a/lib/template_generator/generate_base_template.py
+++ b/lib/template_generator/generate_base_template.py
@@ -89,7 +89,7 @@ def remove_unwanted_content(soup: BeautifulSoup):
         """
         {% block content %}{% endblock content %}
         {% block related_content %}
-        {% include "includes/related_content.html" %}
+        {% include "includes/default_related_content.html" %}
         {% endblock related_content %}
         """,
     )
@@ -109,16 +109,6 @@ def remove_unwanted_content(soup: BeautifulSoup):
         soup.select_one(".c-language-switcher"),
         "{% block language_picker %}{% endblock language_picker %}",
     )
-    # _replace_content(
-    #     soup.select_one(
-    #         "#block-electoralcommission-views-block-related-content-taxonomy-related-2"
-    #     ),
-    #     """
-    #     {% block related_content %}
-    #     {% include "includes/related_content.html" %}
-    #     {% endblock related_content %}
-    #     """,
-    # )
 
     return soup
 

--- a/postcode_lookup/data/pages.json
+++ b/postcode_lookup/data/pages.json
@@ -1,0 +1,194 @@
+{
+  "/i-am-a/voter/register-vote-and-update-your-details": {
+    "en": {
+      "url": "/i-am-a/voter/register-vote-and-update-your-details",
+      "title": "Register to vote",
+      "description": "All you need to register to vote is 5 minutes and your National Insurance number."
+    },
+    "cy": {
+      "url": "/cy/pleidleisio-ac-etholiadau/cofrestru-i-bleidleisio",
+      "title": "Cofrestru i bleidleisio",
+      "description": "Y cwbl sydd ei angen arnoch i gofrestru i bleidleisio yw 5 munud a’ch rhif Yswiriant Gwladol."
+    }
+  },
+  "/i-am-a/voter/apply-vote-post": {
+    "en": {
+      "url": "/i-am-a/voter/apply-vote-post",
+      "title": "Voting by post",
+      "description": "Find out about voting by post in UK elections"
+    },
+    "cy": {
+      "url": "/cy/pleidleisio-ac-etholiadau/ffyrdd-i-bleidleisio/pleidleisio-drwyr-post",
+      "title": "Pleidleisio drwy’r post",
+      "description": "Methu mynd i dy orsaf bleidleisio ar y diwrnod pleidleisio? Gwna gais i bleidleisio drwy'r post ac fe gei di becyn pleidleisio drwy’r post cyn yr etholiad."
+    }
+  },
+  "/i-am-a/voter/apply-vote-proxy": {
+    "en": {
+      "url": "/i-am-a/voter/apply-vote-proxy",
+      "title": "Apply to vote by proxy",
+      "description": "If you can't get to the polling station on polling day, you can ask someone you trust to cast your vote on your behalf."
+    },
+    "cy": {
+      "url": "/cy/pleidleisio-ac-etholiadau/ffyrdd-i-bleidleisio/gwneud-cais-i-bleidleisio-drwy-ddirprwy",
+      "title": "Gwneud cais i bleidleisio drwy ddirprwy",
+      "description": "Os na allu di gyrraedd yr orsaf bleidleisio ar y diwrnod pleidleisio, gallu di ofyn i rywun rwyt ti’n ymddiried ynddo i fwrw dy bleidlais ar dy ran. Gelwir hyn yn bleidlais trwy ddirprwy."
+    }
+  },
+  "/i-am-a/voter/voter-id": {
+    "en": {
+      "url": "/i-am-a/voter/voter-id",
+      "title": "Voter ID",
+      "description": "You need to show photo ID to vote at polling stations in some elections."
+    },
+    "cy": {
+      "url": "/cy/pleidleisio-ac-etholiadau/id-pleidleisiwr",
+      "title": "ID Pleidleisiwr",
+      "description": "Mae angen i chi ddangos ID ffotograffig i bleidleisio mewn gorsafoedd pleidleisio mewn rhai etholiadau."
+    }
+  },
+  "/voting-and-elections/how-elections-work/types-elections/northern-ireland-assembly": {
+    "en": {
+      "url": "/voting-and-elections/how-elections-work/types-elections/northern-ireland-assembly",
+      "title": "Northern Ireland Assembly",
+      "description": "The Northern Ireland Assembly represents the people of Northern Ireland. Northern Ireland Assembly elections usually take place every five years"
+    },
+    "cy": {
+      "url": "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/am-beth-alla-i-bleidleisio/cynulliad-gogledd-iwerddon",
+      "title": "Cynulliad Gogledd Iwerddon",
+      "description": "Mae Cynulliad Gogledd Iwerddon yn cynrychioli pobl Gogledd Iwerddon. Fel arfer cynhelir etholiadau Cynulliad Gogledd Iwerddon bob pum mlynedd"
+    }
+  },
+  "/voting-and-elections/how-elections-work/types-elections/voting-senedd-elections": {
+    "en": {
+      "url": "/voting-and-elections/how-elections-work/types-elections/voting-senedd-elections",
+      "title": "Voting in Senedd elections",
+      "description": "The Senedd represents the people of Wales. Senedd elections take place every five years."
+    },
+    "cy": {
+      "url": "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/am-beth-alla-i-bleidleisio/pleidleisio-yn-etholiadaur-senedd",
+      "title": "Pleidleisio yn Etholiadau'r Senedd",
+      "description": "Mae’r Senedd yn cynrychioli pobl Cymru. Mae etholiadau’r Senedd yn cael eu cynnal bob pum mlynedd"
+    }
+  },
+  "/voting-and-elections/how-elections-work/types-elections/scottish-parliament": {
+    "en": {
+      "url": "/voting-and-elections/how-elections-work/types-elections/scottish-parliament",
+      "title": "Scottish Parliament",
+      "description": "The Scottish Parliament represents the people of Scotland. It has the power to make decisions and pass laws in certain areas"
+    },
+    "cy": {
+      "url": "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/am-beth-alla-i-bleidleisio/senedd-yr-alban",
+      "title": "Senedd yr Alban",
+      "description": "Yma mae mwy o wybodaeth am Senedd yr Alban, gan gynnwys ei gyfansoddiad ac am beth mae'n gyfrifol"
+    }
+  },
+  "/voting-and-elections/how-elections-work/types-elections/police-and-crime-commissioners": {
+    "en": {
+      "url": "/voting-and-elections/how-elections-work/types-elections/police-and-crime-commissioners",
+      "title": "Police and Crime Commissioners",
+      "description": "Police and Crime Commissioners make sure that the local police in their area are meeting the needs of the community"
+    },
+    "cy": {
+      "url": "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/am-beth-alla-i-bleidleisio/comisiynwyr-yr-heddlu-a-throseddu",
+      "title": "Comisiynwyr yr Heddlu a Throseddu",
+      "description": "Mae Comisiynwyr yr Heddlu a Throseddu yn sicrhau bod yr heddlu lleol yn eu hardal yn diwallu anghenion y gymuned"
+    }
+  },
+  "/voting-and-elections/how-elections-work/types-elections/mayoral-elections": {
+    "en": {
+      "url": "/voting-and-elections/how-elections-work/types-elections/mayoral-elections",
+      "title": "Voting in mayoral elections",
+      "description": "Find out about mayoral elections in England and how the voting system works"
+    },
+    "cy": {
+      "url": "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/am-beth-alla-i-bleidleisio/pleidleisio-mewn-etholiadau-maerol",
+      "title": "Pleidleisio mewn etholiadau maerol",
+      "description": "Mae pedwar math o faer yn Lloegr. Mae'r math o faer neu feiri sydd gennych yn dibynnu ar ble rydych chi'n byw"
+    }
+  },
+  "/voting-and-elections/how-elections-work/types-elections/mayor-london-and-london-assembly": {
+    "en": {
+      "url": "/voting-and-elections/how-elections-work/types-elections/mayor-london-and-london-assembly",
+      "title": "Mayor of London and London Assembly",
+      "description": "The Mayor of London and London Assembly represent the people living in London."
+    },
+    "cy": {
+      "url": "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/am-beth-alla-i-bleidleisio/maer-llundain-a-chynulliad-llundain",
+      "title": "Maer Llundain a Chynulliad Llundain",
+      "description": "Mae Maer Llundain a Chynulliad Llundain yn cynrychioli'r bobl sy'n byw yn Llundain"
+    }
+  },
+  "/voting-and-elections/how-elections-work/types-elections/uk-parliamentary-elections": {
+    "en": {
+      "url": "/voting-and-elections/how-elections-work/types-elections/uk-parliamentary-elections",
+      "title": "UK parliamentary by-elections",
+      "description": "UK parliamentary by-elections happen when a seat in the House of Commons becomes vacant between general elections."
+    },
+    "cy": {
+      "url": "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/am-beth-alla-i-bleidleisio/etholiadau-senedd-y-du",
+      "title": "Is-etholiadau Senedd y DU",
+      "description": "UK parliamentary by-elections happen when a seat in the House of Commons becomes vacant between general elections."
+    }
+  },
+  "/voting-and-elections/how-elections-work/types-elections/uk-parliament": {
+    "en": {
+      "url": "/voting-and-elections/how-elections-work/types-elections/uk-parliament",
+      "title": "UK Parliament",
+      "description": "The UK Parliament represents the people of the United Kingdom. It makes decisions and passes laws on a wide range of issues that affect you. Find out more"
+    },
+    "cy": {
+      "url": "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/am-beth-alla-i-bleidleisio/senedd-y-du",
+      "title": "Senedd y DU",
+      "description": "Senedd y DU"
+    }
+  },
+  "/voting-and-elections/how-elections-work/types-elections/local-council-elections": {
+    "en": {
+      "url": "/voting-and-elections/how-elections-work/types-elections/local-council-elections",
+      "title": "Local council by-elections",
+      "description": "Local council by-elections happen when a councillor leaves their seat during their term"
+    },
+    "cy": {
+      "url": "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/am-beth-alla-i-bleidleisio/etholiadau-cynghorau-lleol",
+      "title": "Is-etholiadau cynghorau lleol",
+      "description": "Mae is-etholiadau cynghorau lleol yn digwydd pan fydd cynghorydd yn gadael ei sedd yn ystod ei dymor"
+    }
+  },
+  "/voting-and-elections/how-elections-work/types-elections/local-councils": {
+    "en": {
+      "url": "/voting-and-elections/how-elections-work/types-elections/local-councils",
+      "title": "Local councils",
+      "description": "Find out about local councils and how to vote in local council elections."
+    },
+    "cy": {
+      "url": "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/am-beth-alla-i-bleidleisio/cynghorau-lleol",
+      "title": "Cynghorau lleol",
+      "description": "Cynghorau lleol"
+    }
+  },
+  "/voting-and-elections/how-elections-work/types-elections": {
+    "en": {
+      "url": "/voting-and-elections/how-elections-work/types-elections",
+      "title": "Types of elections",
+      "description": "Find out more about the types of elections in the UK."
+    },
+    "cy": {
+      "url": "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/mathau-o-etholiadau",
+      "title": "Mathau o etholiadau",
+      "description": "Darganfyddwch ragor am y mathau o etholiadau a gynhelir yn y DU."
+    }
+  },
+  "/voting-and-elections": {
+    "en": {
+      "url": "/voting-and-elections",
+      "title": "Voter information",
+      "description": "Everything you need to know about voting in UK elections"
+    },
+    "cy": {
+      "url": "/cy/pleidleisio-ac-etholiadau",
+      "title": "Pleidleisio ac etholiadau",
+      "description": "Dysgwch bopeth sydd angen ei chi wybod am bleidleisio ac etholiadau, gan gynnwys gwybodaeth am etholiadau sydd i ddod yn eich ardal."
+    }
+  }
+}

--- a/postcode_lookup/locale/cy/LC_MESSAGES/messages.po
+++ b/postcode_lookup/locale/cy/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: EC postcode pages\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-04-27 14:31+0100\n"
+"POT-Creation-Date: 2026-04-29 13:48+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: cy\n"
@@ -15,81 +15,81 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.16.0\n"
 
-#: postcode_lookup/template_sorter.py:106
-#: postcode_lookup/template_sorter.py:127
+#: postcode_lookup/template_sorter.py:107
+#: postcode_lookup/template_sorter.py:128
 msgid "Where to vote"
 msgstr "Ble i bleidleisio"
 
-#: postcode_lookup/template_sorter.py:261
+#: postcode_lookup/template_sorter.py:262
 #: postcode_lookup/templates/includes/postal_votes.html:1
 msgid "Voting by post"
 msgstr "Pleidleisio drwy'r post"
 
-#: postcode_lookup/template_sorter.py:296
-#: postcode_lookup/template_sorter.py:323
+#: postcode_lookup/template_sorter.py:297
+#: postcode_lookup/template_sorter.py:324
 #: postcode_lookup/templates/includes/registration_timetable.html:1
 #: postcode_lookup/templates/includes/registration_timetable_city_of_london.html:8
 msgid "Voter registration"
 msgstr "Cofrestru pleidleiswyr"
 
-#: postcode_lookup/template_sorter.py:369
+#: postcode_lookup/template_sorter.py:370
 msgid "7am – 10pm"
 msgstr "7am – 10pm"
 
-#: postcode_lookup/template_sorter.py:374
+#: postcode_lookup/template_sorter.py:375
 msgid "8am – 8pm"
 msgstr "8am – 8pm"
 
-#: postcode_lookup/template_sorter.py:392
+#: postcode_lookup/template_sorter.py:393
 msgid "There may also be parish or town council elections in some areas."
 msgstr "Efallai y bydd etholiadau cyngor plwyf neu dref mewn rhai ardaloedd hefyd."
 
-#: postcode_lookup/template_sorter.py:396
+#: postcode_lookup/template_sorter.py:397
 msgid "There may also be community council elections in some areas."
 msgstr "Efallai y bydd etholiadau cyngor cymuned mewn rhai ardaloedd hefyd."
 
-#: postcode_lookup/template_sorter.py:400
+#: postcode_lookup/template_sorter.py:401
 msgid "There may also be town or community council elections in some areas."
 msgstr ""
 "Mae'n bosib y bydd etholiadau cynghorau tref neu gymuned mewn rhai "
 "ardaloedd."
 
-#: postcode_lookup/template_sorter.py:587
+#: postcode_lookup/template_sorter.py:595
 msgid "There are no upcoming elections in your area"
 msgstr "Nid oes etholiadau ar y gweill yn eich ardal"
 
-#: postcode_lookup/template_sorter.py:593
+#: postcode_lookup/template_sorter.py:601
 msgid "Uncontested"
 msgstr "Heb gystadleuaeth"
 
-#: postcode_lookup/template_sorter.py:596
-#: postcode_lookup/template_sorter.py:601
+#: postcode_lookup/template_sorter.py:604
+#: postcode_lookup/template_sorter.py:609
 msgid "Postponed"
 msgstr "Wedi'i ohirio"
 
-#: postcode_lookup/template_sorter.py:611
+#: postcode_lookup/template_sorter.py:619
 msgid "You have an election today"
 msgstr "Mae gennych etholiad heddiw"
 
-#: postcode_lookup/template_sorter.py:614
+#: postcode_lookup/template_sorter.py:622
 msgid "You have an upcoming election"
 msgstr "Mae gennych etholiad sydd ar y gweill"
 
-#: postcode_lookup/template_sorter.py:617
-#: postcode_lookup/template_sorter.py:620
+#: postcode_lookup/template_sorter.py:625
+#: postcode_lookup/template_sorter.py:628
 msgid "You have upcoming elections"
 msgstr "Mae gennych etholiadau sydd ar y gweill"
 
-#: postcode_lookup/template_sorter.py:690
+#: postcode_lookup/template_sorter.py:698
 #: postcode_lookup/templates/includes/organisation_contact.html:36
 msgid "Your local council"
 msgstr "Eich cyngor lleol"
 
-#: postcode_lookup/template_sorter.py:697
+#: postcode_lookup/template_sorter.py:705
 msgid "Electoral registration"
 msgstr "Cofrestru etholiadol"
 
-#: postcode_lookup/template_sorter.py:703
+#: postcode_lookup/template_sorter.py:711
 #: postcode_lookup/templates/includes/organisation_contact.html:25
 msgid "Your returning officer"
 msgstr "Eich swyddog canlyniadau"
@@ -321,19 +321,19 @@ msgstr "Mewnbynnwch eich cod post i ganfod pwy yw’r ymgeiswyr yn eich ardal."
 msgid "On this page"
 msgstr "Ar y dudalen hon"
 
-#: postcode_lookup/templates/includes/ballots.html:10
+#: postcode_lookup/templates/includes/ballots.html:9
 msgid "parties and independent candidates"
 msgstr "pleidiau ac ymgeiswyr annibynnol"
 
-#: postcode_lookup/templates/includes/ballots.html:12
+#: postcode_lookup/templates/includes/ballots.html:11
 msgid "candidates"
 msgstr "ymgeiswyr"
 
-#: postcode_lookup/templates/includes/ballots.html:30
+#: postcode_lookup/templates/includes/ballots.html:29
 msgid "Find out more about the candidates in your area on WhoCanIVoteFor.co.uk"
 msgstr "Dysgwch ragor am yr ymgeiswyr yn eich ardal ar WhoCanIVoteFor.co.uk"
 
-#: postcode_lookup/templates/includes/ballots.html:39
+#: postcode_lookup/templates/includes/ballots.html:37
 #, python-format
 msgid ""
 "<h3>%(ballot_title)s candidates</h3> <p>The list of candidates for this "
@@ -395,6 +395,84 @@ msgstr ""
 "na nifer y seddau sydd ar gael. Bydd yr etholiad yn cael ei aildrefnu a'i"
 " gynnal o fewn 35 diwrnod o'r diwrnod pleidleisio gwreiddiol "
 "(%(initial_poll_date)s)."
+
+#: postcode_lookup/templates/includes/default_related_content.html:4
+#: postcode_lookup/templates/includes/related_content.html:4
+msgid "Related content"
+msgstr "Cynnwys cysylltiedig"
+
+#: postcode_lookup/templates/includes/default_related_content.html:11
+#: postcode_lookup/templates/includes/registration_timetable.html:3
+#: postcode_lookup/templates/includes/registration_timetable.html:11
+#: postcode_lookup/templates/includes/registration_timetable_city_of_london.html:12
+msgid "Register to vote"
+msgstr "Cofrestra i bleidleisio"
+
+#: postcode_lookup/templates/includes/default_related_content.html:12
+msgid "/i-am-a/voter/register-vote-and-update-your-details"
+msgstr "/cy/pleidleisio-ac-etholiadau/cofrestru-i-bleidleisio"
+
+#: postcode_lookup/templates/includes/default_related_content.html:13
+msgid ""
+"All you need to register to vote is 5 minutes and your National Insurance"
+" number. Make sure you register to vote before the deadline for the "
+"elections in May."
+msgstr ""
+"Y cwbl sydd ei angen arnoch i gofrestru i bleidleisio yw 5 munud a’ch "
+"rhif Yswiriant Gwladol."
+
+#: postcode_lookup/templates/includes/default_related_content.html:19
+msgid "Apply to vote by post"
+msgstr "Gwneud cais i bleidleisio drwy'r post"
+
+#: postcode_lookup/templates/includes/default_related_content.html:20
+msgid "/i-am-a/voter/apply-vote-post"
+msgstr ""
+"/cy/pleidleisio-ac-etholiadau/ffyrdd-i-bleidleisio/sut-i-bleidleisio-"
+"trwyr-post"
+
+#: postcode_lookup/templates/includes/default_related_content.html:21
+msgid ""
+"Can't get to the polling station on polling day? Apply to vote by post by"
+" downloading and completing the application form."
+msgstr ""
+"Methu mynd i’r orsaf bleidleisio ar y diwrnod pleidleisio? Gwnewch gais i"
+" bleidleisio drwy’r post trwy lawrlwytho a chwblhau’r ffurflen gais."
+
+#: postcode_lookup/templates/includes/default_related_content.html:27
+msgid "Apply to vote by proxy"
+msgstr "Gwneud cais i bleidleisio drwy ddirprwy"
+
+#: postcode_lookup/templates/includes/default_related_content.html:28
+msgid "/i-am-a/voter/apply-vote-proxy"
+msgstr ""
+"/cy/pleidleisio-ac-etholiadau/ffyrdd-i-bleidleisio/gwneud-cais-i"
+"-bleidleisio-drwy-ddirprwy"
+
+#: postcode_lookup/templates/includes/default_related_content.html:29
+msgid ""
+"Can't get to the polling station on polling day? Ask a trusted person to "
+"vote on your behalf and apply for a proxy vote."
+msgstr ""
+"Os na allu di gyrraedd yr orsaf bleidleisio ar y diwrnod pleidleisio, "
+"gallu di ofyn i rywun rwyt ti’n ymddiried ynddo i fwrw dy bleidlais ar dy"
+" ran. Gelwir hyn yn bleidlais trwy ddirprwy."
+
+#: postcode_lookup/templates/includes/default_related_content.html:35
+msgid "Voter ID requirement"
+msgstr "Gofyniad ID Pleidleisiwr"
+
+#: postcode_lookup/templates/includes/default_related_content.html:36
+msgid "/i-am-a/voter/voter-id"
+msgstr "/cy/pleidleisio-ac-etholiadau/id-pleidleisiwr"
+
+#: postcode_lookup/templates/includes/default_related_content.html:37
+msgid ""
+"From 4 May 2023, voters in England will need to show photo ID to vote at "
+"polling stations in some elections."
+msgstr ""
+"Mae angen i bleidleiswyr yng Nghymru ddangos ID ffotograffig i "
+"bleidleisio mewn gorsafoedd pleidleisio mewn rhai etholiadau."
 
 #: postcode_lookup/templates/includes/feedback_section.html:2
 msgid "Feedback"
@@ -647,13 +725,6 @@ msgstr "Y cwestiwn a ofynnir i chi ar y papur pleidleisio yw:"
 msgid "Read more about this referendum"
 msgstr "Darllenwch ragor o wybodaeth am y refferendwm hwn"
 
-#: postcode_lookup/templates/includes/registration_timetable.html:3
-#: postcode_lookup/templates/includes/registration_timetable.html:11
-#: postcode_lookup/templates/includes/registration_timetable_city_of_london.html:12
-#: postcode_lookup/templates/includes/related_content.html:11
-msgid "Register to vote"
-msgstr "Cofrestra i bleidleisio"
-
 #: postcode_lookup/templates/includes/registration_timetable.html:5
 #, python-format
 msgid "You have until %(date)s"
@@ -676,76 +747,6 @@ msgstr ""
 "ar y gofrestr.</p> <p>Gallwch <a "
 "href=\"https://www.gov.uk/cofrestru-i-bleidleisio/\">gofrestru i "
 "bleidleisio</a> mewn etholiadau yn y dyfodol.</p>"
-
-#: postcode_lookup/templates/includes/related_content.html:4
-msgid "Related content"
-msgstr "Cynnwys cysylltiedig"
-
-#: postcode_lookup/templates/includes/related_content.html:12
-msgid "/i-am-a/voter/register-vote-and-update-your-details"
-msgstr "/cy/pleidleisio-ac-etholiadau/cofrestru-i-bleidleisio"
-
-#: postcode_lookup/templates/includes/related_content.html:13
-msgid ""
-"All you need to register to vote is 5 minutes and your National Insurance"
-" number. Make sure you register to vote before the deadline for the "
-"elections in May."
-msgstr ""
-"Y cwbl sydd ei angen arnoch i gofrestru i bleidleisio yw 5 munud a’ch "
-"rhif Yswiriant Gwladol."
-
-#: postcode_lookup/templates/includes/related_content.html:19
-msgid "Apply to vote by post"
-msgstr "Gwneud cais i bleidleisio drwy'r post"
-
-#: postcode_lookup/templates/includes/related_content.html:20
-msgid "/i-am-a/voter/apply-vote-post"
-msgstr ""
-"/cy/pleidleisio-ac-etholiadau/ffyrdd-i-bleidleisio/sut-i-bleidleisio-"
-"trwyr-post"
-
-#: postcode_lookup/templates/includes/related_content.html:21
-msgid ""
-"Can't get to the polling station on polling day? Apply to vote by post by"
-" downloading and completing the application form."
-msgstr ""
-"Methu mynd i’r orsaf bleidleisio ar y diwrnod pleidleisio? Gwnewch gais i"
-" bleidleisio drwy’r post trwy lawrlwytho a chwblhau’r ffurflen gais."
-
-#: postcode_lookup/templates/includes/related_content.html:27
-msgid "Apply to vote by proxy"
-msgstr "Gwneud cais i bleidleisio drwy ddirprwy"
-
-#: postcode_lookup/templates/includes/related_content.html:28
-msgid "/i-am-a/voter/apply-vote-proxy"
-msgstr ""
-"/cy/pleidleisio-ac-etholiadau/ffyrdd-i-bleidleisio/gwneud-cais-i"
-"-bleidleisio-drwy-ddirprwy"
-
-#: postcode_lookup/templates/includes/related_content.html:29
-msgid ""
-"Can't get to the polling station on polling day? Ask a trusted person to "
-"vote on your behalf and apply for a proxy vote."
-msgstr ""
-"Os na allu di gyrraedd yr orsaf bleidleisio ar y diwrnod pleidleisio, "
-"gallu di ofyn i rywun rwyt ti’n ymddiried ynddo i fwrw dy bleidlais ar dy"
-" ran. Gelwir hyn yn bleidlais trwy ddirprwy."
-
-#: postcode_lookup/templates/includes/related_content.html:35
-msgid "Voter ID requirement"
-msgstr "Gofyniad ID Pleidleisiwr"
-
-#: postcode_lookup/templates/includes/related_content.html:36
-msgid "/i-am-a/voter/voter-id"
-msgstr "/cy/pleidleisio-ac-etholiadau/id-pleidleisiwr"
-
-#: postcode_lookup/templates/includes/related_content.html:37
-msgid ""
-"From 4 May 2023, voters in England will need to show photo ID to vote at "
-"polling stations in some elections."
-msgstr ""
-"Mae angen i bleidleiswyr yng Nghymru ddangos ID ffotograffig i "
-"bleidleisio mewn gorsafoedd pleidleisio mewn rhai etholiadau."
 
 #: postcode_lookup/templates/includes/single_date.html:9
 #, python-format

--- a/postcode_lookup/locale/cy/LC_MESSAGES/messages.po
+++ b/postcode_lookup/locale/cy/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: EC postcode pages\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-23 13:11+0100\n"
+"POT-Creation-Date: 2026-07-07 09:17+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: cy\n"
@@ -15,86 +15,86 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.16.0\n"
 
-#: postcode_lookup/template_sorter.py:105
-#: postcode_lookup/template_sorter.py:141
+#: postcode_lookup/template_sorter.py:107
+#: postcode_lookup/template_sorter.py:143
 msgid "Where to vote"
 msgstr "Ble i bleidleisio"
 
-#: postcode_lookup/template_sorter.py:280
+#: postcode_lookup/template_sorter.py:282
 #: postcode_lookup/templates/includes/postal_votes.html:1
 msgid "Voting by post"
 msgstr "Pleidleisio drwy'r post"
 
-#: postcode_lookup/template_sorter.py:315
-#: postcode_lookup/template_sorter.py:342
+#: postcode_lookup/template_sorter.py:317
+#: postcode_lookup/template_sorter.py:344
 #: postcode_lookup/templates/includes/registration_timetable.html:1
 #: postcode_lookup/templates/includes/registration_timetable_city_of_london.html:8
 msgid "Voter registration"
 msgstr "Cofrestru pleidleiswyr"
 
-#: postcode_lookup/template_sorter.py:389
+#: postcode_lookup/template_sorter.py:391
 msgid "7am – 10pm"
 msgstr "7am – 10pm"
 
-#: postcode_lookup/template_sorter.py:394
+#: postcode_lookup/template_sorter.py:396
 msgid "8am – 8pm"
 msgstr "8am – 8pm"
 
-#: postcode_lookup/template_sorter.py:412
+#: postcode_lookup/template_sorter.py:414
 msgid "There may also be parish or town council elections in some areas."
 msgstr "Efallai y bydd etholiadau cyngor plwyf neu dref mewn rhai ardaloedd hefyd."
 
-#: postcode_lookup/template_sorter.py:416
+#: postcode_lookup/template_sorter.py:418
 msgid "There may also be community council elections in some areas."
 msgstr "Efallai y bydd etholiadau cyngor cymuned mewn rhai ardaloedd hefyd."
 
-#: postcode_lookup/template_sorter.py:420
+#: postcode_lookup/template_sorter.py:422
 msgid "There may also be town or community council elections in some areas."
 msgstr ""
 "Mae'n bosib y bydd etholiadau cynghorau tref neu gymuned mewn rhai "
 "ardaloedd."
 
-#: postcode_lookup/template_sorter.py:611
+#: postcode_lookup/template_sorter.py:620
 msgid "There are no upcoming elections in your area"
 msgstr "Nid oes etholiadau ar y gweill yn eich ardal"
 
-#: postcode_lookup/template_sorter.py:617
+#: postcode_lookup/template_sorter.py:626
 msgid "Uncontested"
 msgstr "Heb gystadleuaeth"
 
-#: postcode_lookup/template_sorter.py:620
-#: postcode_lookup/template_sorter.py:625
+#: postcode_lookup/template_sorter.py:629
+#: postcode_lookup/template_sorter.py:634
 msgid "Postponed"
 msgstr "Wedi'i ohirio"
 
-#: postcode_lookup/template_sorter.py:635
+#: postcode_lookup/template_sorter.py:644
 msgid "You have an election today"
 msgstr "Mae gennych etholiad heddiw"
 
-#: postcode_lookup/template_sorter.py:638
+#: postcode_lookup/template_sorter.py:647
 msgid "You have an upcoming election"
 msgstr "Mae gennych etholiad sydd ar y gweill"
 
-#: postcode_lookup/template_sorter.py:641
-#: postcode_lookup/template_sorter.py:644
+#: postcode_lookup/template_sorter.py:650
+#: postcode_lookup/template_sorter.py:653
 msgid "You have upcoming elections"
 msgstr "Mae gennych etholiadau sydd ar y gweill"
 
-#: postcode_lookup/template_sorter.py:714
+#: postcode_lookup/template_sorter.py:723
 #: postcode_lookup/templates/includes/organisation_contact.html:36
 msgid "Your local council"
 msgstr "Eich cyngor lleol"
 
-#: postcode_lookup/template_sorter.py:721
+#: postcode_lookup/template_sorter.py:730
 msgid "Electoral registration"
 msgstr "Cofrestru etholiadol"
 
-#: postcode_lookup/template_sorter.py:727
+#: postcode_lookup/template_sorter.py:736
 #: postcode_lookup/templates/includes/organisation_contact.html:25
 msgid "Your returning officer"
 msgstr "Eich swyddog canlyniadau"
 
-#: postcode_lookup/utils.py:166
+#: postcode_lookup/utils.py:167
 #, fuzzy
 msgid "{count} candidate"
 msgid_plural "{count} candidates"
@@ -104,47 +104,47 @@ msgstr[2] "{count} ymgeiswyr"
 msgstr[3] "{count} ymgeiswyr"
 msgstr[4] "{count} ymgeiswyr"
 
-#: postcode_lookup/utils.py:187
+#: postcode_lookup/utils.py:188
 msgid "one"
 msgstr "un"
 
-#: postcode_lookup/utils.py:188
+#: postcode_lookup/utils.py:189
 msgid "two"
 msgstr "dau"
 
-#: postcode_lookup/utils.py:189
+#: postcode_lookup/utils.py:190
 msgid "three"
 msgstr "tri"
 
-#: postcode_lookup/utils.py:190
+#: postcode_lookup/utils.py:191
 msgid "four"
 msgstr "pedwar"
 
-#: postcode_lookup/utils.py:191
+#: postcode_lookup/utils.py:192
 msgid "five"
 msgstr "pump"
 
-#: postcode_lookup/utils.py:192
+#: postcode_lookup/utils.py:193
 msgid "six"
 msgstr "chwech"
 
-#: postcode_lookup/utils.py:193
+#: postcode_lookup/utils.py:194
 msgid "seven"
 msgstr "saith"
 
-#: postcode_lookup/utils.py:194
+#: postcode_lookup/utils.py:195
 msgid "eight"
 msgstr "wyth"
 
-#: postcode_lookup/utils.py:195
+#: postcode_lookup/utils.py:196
 msgid "nine"
 msgstr "naw"
 
-#: postcode_lookup/utils.py:249 postcode_lookup/utils.py:252
+#: postcode_lookup/utils.py:250 postcode_lookup/utils.py:253
 msgid " (postponed)"
 msgstr " (wedi'i ohirio)"
 
-#: postcode_lookup/utils.py:255
+#: postcode_lookup/utils.py:256
 msgid " (uncontested)"
 msgstr " (heb gystadleuaeth)"
 
@@ -346,7 +346,6 @@ msgstr ""
 "gyfer yr etholiad hwn ar ôl %(sopn_date)s.</p>"
 
 #: postcode_lookup/templates/includes/ballots.html:50
-#: postcode_lookup/templates/includes/related_content.html:35
 msgid "Voter ID requirement"
 msgstr "Gofyniad ID Pleidleisiwr"
 
@@ -433,6 +432,11 @@ msgid ""
 msgstr ""
 "Os nad ydych wedi derbyn eich cerdyn pleidleisio, <a href=\"#electoral-"
 "services\">cysylltwch â’ch cyngor lleol</a>."
+
+#: postcode_lookup/templates/includes/default_related_content.html:4
+#: postcode_lookup/templates/includes/related_content.html:4
+msgid "Related content"
+msgstr "Cynnwys cysylltiedig"
 
 #: postcode_lookup/templates/includes/feedback_section.html:2
 msgid "Feedback"
@@ -709,7 +713,6 @@ msgstr "Darllenwch ragor o wybodaeth am y refferendwm hwn"
 #: postcode_lookup/templates/includes/registration_timetable.html:3
 #: postcode_lookup/templates/includes/registration_timetable.html:11
 #: postcode_lookup/templates/includes/registration_timetable_city_of_london.html:12
-#: postcode_lookup/templates/includes/related_content.html:11
 msgid "Register to vote"
 msgstr "Cofrestra i bleidleisio"
 
@@ -735,72 +738,6 @@ msgstr ""
 "ar y gofrestr.</p> <p>Gallwch <a "
 "href=\"https://www.gov.uk/cofrestru-i-bleidleisio/\">gofrestru i "
 "bleidleisio</a> mewn etholiadau yn y dyfodol.</p>"
-
-#: postcode_lookup/templates/includes/related_content.html:4
-msgid "Related content"
-msgstr "Cynnwys cysylltiedig"
-
-#: postcode_lookup/templates/includes/related_content.html:12
-msgid "/i-am-a/voter/register-vote-and-update-your-details"
-msgstr "/cy/pleidleisio-ac-etholiadau/cofrestru-i-bleidleisio"
-
-#: postcode_lookup/templates/includes/related_content.html:13
-msgid ""
-"All you need to register to vote is 5 minutes and your National Insurance"
-" number. Make sure you register to vote before the deadline for the "
-"elections in May."
-msgstr ""
-"Y cwbl sydd ei angen arnoch i gofrestru i bleidleisio yw 5 munud a’ch "
-"rhif Yswiriant Gwladol."
-
-#: postcode_lookup/templates/includes/related_content.html:19
-msgid "Apply to vote by post"
-msgstr "Gwneud cais i bleidleisio drwy'r post"
-
-#: postcode_lookup/templates/includes/related_content.html:20
-msgid "/i-am-a/voter/apply-vote-post"
-msgstr ""
-"/cy/pleidleisio-ac-etholiadau/ffyrdd-i-bleidleisio/sut-i-bleidleisio-"
-"trwyr-post"
-
-#: postcode_lookup/templates/includes/related_content.html:21
-msgid ""
-"Can't get to the polling station on polling day? Apply to vote by post by"
-" downloading and completing the application form."
-msgstr ""
-"Methu mynd i’r orsaf bleidleisio ar y diwrnod pleidleisio? Gwnewch gais i"
-" bleidleisio drwy’r post trwy lawrlwytho a chwblhau’r ffurflen gais."
-
-#: postcode_lookup/templates/includes/related_content.html:27
-msgid "Apply to vote by proxy"
-msgstr "Gwneud cais i bleidleisio drwy ddirprwy"
-
-#: postcode_lookup/templates/includes/related_content.html:28
-msgid "/i-am-a/voter/apply-vote-proxy"
-msgstr ""
-"/cy/pleidleisio-ac-etholiadau/ffyrdd-i-bleidleisio/gwneud-cais-i"
-"-bleidleisio-drwy-ddirprwy"
-
-#: postcode_lookup/templates/includes/related_content.html:29
-msgid ""
-"Can't get to the polling station on polling day? Ask a trusted person to "
-"vote on your behalf and apply for a proxy vote."
-msgstr ""
-"Os na allu di gyrraedd yr orsaf bleidleisio ar y diwrnod pleidleisio, "
-"gallu di ofyn i rywun rwyt ti’n ymddiried ynddo i fwrw dy bleidlais ar dy"
-" ran. Gelwir hyn yn bleidlais trwy ddirprwy."
-
-#: postcode_lookup/templates/includes/related_content.html:36
-msgid "/i-am-a/voter/voter-id"
-msgstr "/cy/pleidleisio-ac-etholiadau/id-pleidleisiwr"
-
-#: postcode_lookup/templates/includes/related_content.html:37
-msgid ""
-"From 4 May 2023, voters in England will need to show photo ID to vote at "
-"polling stations in some elections."
-msgstr ""
-"Mae angen i bleidleiswyr yng Nghymru ddangos ID ffotograffig i "
-"bleidleisio mewn gorsafoedd pleidleisio mewn rhai etholiadau."
 
 #: postcode_lookup/templates/includes/single_date.html:9
 #, python-format

--- a/postcode_lookup/related_content.py
+++ b/postcode_lookup/related_content.py
@@ -1,0 +1,176 @@
+RELATED_CONTENT = {
+    "nia": {
+        "en": (
+            "Northern Ireland Assembly",
+            "/voting-and-elections/how-elections-work/types-elections/northern-ireland-assembly",
+        ),
+        "cy": (
+            "Cynulliad Gogledd Iwerddon",
+            "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/am-beth-alla-i-bleidleisio/cynulliad-gogledd-iwerddon",
+        ),
+    },
+    "senedd": {
+        "en": (
+            "Voting in Senedd elections",
+            "/voting-and-elections/how-elections-work/types-elections/voting-senedd-elections",
+        ),
+        "cy": (
+            "Pleidleisio yn Etholiadau'r Senedd",
+            "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/am-beth-alla-i-bleidleisio/pleidleisio-yn-etholiadaur-senedd",
+        ),
+    },
+    "sp": {
+        "en": (
+            "Scottish Parliament",
+            "/voting-and-elections/how-elections-work/types-elections/scottish-parliament",
+        ),
+        "cy": (
+            "Senedd yr Alban",
+            "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/am-beth-alla-i-bleidleisio/senedd-yr-alban",
+        ),
+    },
+    "pcc": {
+        "en": (
+            "Police and Crime Commissioners",
+            "/voting-and-elections/how-elections-work/types-elections/police-and-crime-commissioners",
+        ),
+        "cy": (
+            "Comisiynwyr yr Heddlu a Throseddu",
+            "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/am-beth-alla-i-bleidleisio/comisiynwyr-yr-heddlu-a-throseddu",
+        ),
+    },
+    "mayor": {
+        "en": (
+            "Mayoral elections",
+            "/voting-and-elections/how-elections-work/types-elections/mayoral-elections",
+        ),
+        "cy": (
+            "Etholiadau maerol",
+            "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/am-beth-alla-i-bleidleisio/etholiadau-maerol",
+        ),
+    },
+    "gla": {
+        "en": (
+            "Mayor of London and London Assembly",
+            "/voting-and-elections/how-elections-work/types-elections/mayor-london-and-london-assembly",
+        ),
+        "cy": (
+            "Maer Llundain a Chynulliad Llundain",
+            "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/am-beth-alla-i-bleidleisio/maer-llundain-a-chynulliad-llundain",
+        ),
+    },
+    "parl.by": {
+        "en": (
+            "UK parliamentary by-elections",
+            "/voting-and-elections/how-elections-work/types-elections/uk-parliamentary-elections",
+        ),
+        "cy": (
+            "Is-etholiadau Senedd y DU",
+            "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/am-beth-alla-i-bleidleisio/etholiadau-senedd-y-du",
+        ),
+    },
+    "parl": {
+        "en": (
+            "UK Parliament",
+            "/voting-and-elections/how-elections-work/types-elections/uk-parliament",
+        ),
+        "cy": (
+            "Senedd y DU",
+            "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/am-beth-alla-i-bleidleisio/senedd-y-du",
+        ),
+    },
+    "local.by": {
+        "en": (
+            "Local council by-elections",
+            "/voting-and-elections/how-elections-work/types-elections/local-council-elections",
+        ),
+        "cy": (
+            "Is-etholiadau cynghorau lleol",
+            "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/am-beth-alla-i-bleidleisio/etholiadau-cynghorau-lleol",
+        ),
+    },
+    "local": {
+        "en": (
+            "Local councils",
+            "/voting-and-elections/how-elections-work/types-elections/local-councils",
+        ),
+        "cy": (
+            "Cynghorau lleol",
+            "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/am-beth-alla-i-bleidleisio/cynghorau-lleol",
+        ),
+    },
+}
+
+
+def get_content_key(ballot_id):
+    id_parts = ballot_id.split(".")
+    election_type = id_parts[0]
+    org = id_parts[1]
+    by_election = id_parts[-2] == "by"
+
+    if election_type == "mayor" and org != "london":
+        return "mayor"
+    if (election_type == "mayor" and org == "london") or (
+        election_type == "gla"
+    ):
+        return "gla"
+    if by_election and election_type in ("parl", "local"):
+        return f"{election_type}.by"
+    return election_type
+
+
+def get_related_content(dates, language):
+    related_content = []
+    seen_keys = set()
+
+    """
+    Add related for election types, limiting to a max of 2
+    and avoiding duplicates.
+
+    Ballots are already sorted by date and charisma
+    so if there are upcoming elections of 3 or more types, we will
+    drop the ones that are furthest in the future/least charismatic
+    """
+    for date in dates:
+        for ballot in date.ballots:
+            key = get_content_key(ballot.ballot_paper_id)
+            if key in RELATED_CONTENT and key not in seen_keys:
+                related_content.append(RELATED_CONTENT[key][language])
+                seen_keys.add(key)
+
+            if len(related_content) == 2:
+                break
+
+        if len(related_content) == 2:
+            break
+
+    # always show these links
+    if language == "cy":
+        related_content.append(
+            (
+                "Mathau o etholiadau",
+                "/cy/pleidleisio-ac-etholiadau/sut-mae-etholiadaun-gweithio/mathau-o-etholiadau",
+            )
+        )
+        related_content.append(
+            (
+                "Pleidleisio ac etholiadau",
+                "/cy/pleidleisio-ac-etholiadau",
+            )
+        )
+    else:
+        # en
+        related_content.append(
+            (
+                "Types of elections",
+                "/voting-and-elections/how-elections-work/types-elections",
+            )
+        )
+        related_content.append(
+            (
+                "Voting and elections",
+                "/voting-and-elections",
+            )
+        )
+
+    return related_content

--- a/postcode_lookup/related_content.py
+++ b/postcode_lookup/related_content.py
@@ -1,0 +1,69 @@
+import json
+from pathlib import Path
+
+with open(Path(__file__).parent / "data" / "pages.json") as f:
+    PAGES = json.load(f)
+
+
+def get_page_metadata(url, language="en"):
+    return PAGES[url][language]
+
+
+RELATED_CONTENT = {
+    "nia": "/voting-and-elections/how-elections-work/types-elections/northern-ireland-assembly",
+    "senedd": "/voting-and-elections/how-elections-work/types-elections/voting-senedd-elections",
+    "sp": "/voting-and-elections/how-elections-work/types-elections/scottish-parliament",
+    "pcc": "/voting-and-elections/how-elections-work/types-elections/police-and-crime-commissioners",
+    "mayor": "/voting-and-elections/how-elections-work/types-elections/mayoral-elections",
+    "gla": "/voting-and-elections/how-elections-work/types-elections/mayor-london-and-london-assembly",
+    "parl.by": "/voting-and-elections/how-elections-work/types-elections/uk-parliamentary-elections",
+    "parl": "/voting-and-elections/how-elections-work/types-elections/uk-parliament",
+    "local.by": "/voting-and-elections/how-elections-work/types-elections/local-council-elections",
+    "local": "/voting-and-elections/how-elections-work/types-elections/local-councils",
+}
+
+
+def get_content_key(ballot_id):
+    id_parts = ballot_id.split(".")
+    election_type = id_parts[0]
+    org = id_parts[1]
+    by_election = id_parts[-2] == "by"
+
+    if election_type == "mayor" and org != "london":
+        return "mayor"
+    if (election_type == "mayor" and org == "london") or (
+        election_type == "gla"
+    ):
+        return "gla"
+    if by_election and election_type in ("parl", "local"):
+        return f"{election_type}.by"
+    return election_type
+
+
+def get_related_content(dates, language):
+    related_content = []
+    seen_keys = set()
+
+    """
+    Add related for election types, avoiding duplicates.
+
+    Ballots are already sorted by date and charisma
+    so we will prioritise elections that are soon/interesting
+    """
+    for date in dates:
+        for ballot in date.ballots:
+            key = get_content_key(ballot.ballot_paper_id)
+            if key in RELATED_CONTENT and key not in seen_keys:
+                related_content.append(
+                    get_page_metadata(RELATED_CONTENT[key], language)
+                )
+                seen_keys.add(key)
+
+    related_content.append(
+        get_page_metadata(
+            "/voting-and-elections/how-elections-work/types-elections", language
+        )
+    )
+    related_content.append(get_page_metadata("/voting-and-elections", language))
+
+    return related_content[:4]

--- a/postcode_lookup/template_sorter.py
+++ b/postcode_lookup/template_sorter.py
@@ -6,7 +6,9 @@ from typing import Dict, List, Optional
 
 from dateparser import parse
 from postal_votes import get_postal_vote_dispatch_dates
+from related_content import get_related_content
 from response_builder.v1.models.base import Date, RootModel
+from starlette_babel import get_locale
 from starlette_babel import gettext_lazy as _
 from uk_election_timetables.calendars import Country
 from uk_election_timetables.election import TimetableEvent
@@ -553,6 +555,13 @@ class TemplateSorter:
         self.all_cancelled_reasons = set()
         for date in self.dates:
             self.all_cancelled_reasons.update(date.cancellation_reasons)
+
+    @property
+    def related_content(self):
+        locale = get_locale()
+        if locale.language not in ["en", "cy"]:
+            return []
+        return get_related_content(self.api_response.dates, locale.language)
 
     @property
     def response_type(self):

--- a/postcode_lookup/template_sorter.py
+++ b/postcode_lookup/template_sorter.py
@@ -6,7 +6,9 @@ from typing import Dict, List, Optional
 
 from dateparser import parse
 from postal_votes import get_postal_vote_dispatch_dates
+from related_content import get_related_content
 from response_builder.v1.models.base import Date, RootModel
+from starlette_babel import get_locale
 from starlette_babel import gettext_lazy as _
 from uk_election_timetables.calendars import Country
 from uk_election_timetables.election import TimetableEvent
@@ -578,6 +580,13 @@ class TemplateSorter:
         self.all_cancelled_reasons = set()
         for date in self.dates:
             self.all_cancelled_reasons.update(date.cancellation_reasons)
+
+    @property
+    def related_content(self):
+        locale = get_locale()
+        if locale.language not in ["en", "cy"]:
+            return []
+        return get_related_content(self.api_response.dates, locale.language)
 
     @property
     def response_type(self):

--- a/postcode_lookup/templates/base.html
+++ b/postcode_lookup/templates/base.html
@@ -1129,7 +1129,7 @@
           <div id="block-electoralcommission-mainpagecontent">
            {% block content %}{% endblock content %}
         {% block related_content %}
-        {% include "includes/related_content.html" %}
+        {% include "includes/default_related_content.html" %}
         {% endblock related_content %}
           </div>
          </div>

--- a/postcode_lookup/templates/base_cy.html
+++ b/postcode_lookup/templates/base_cy.html
@@ -1091,7 +1091,7 @@
           <div id="block-electoralcommission-mainpagecontent">
            {% block content %}{% endblock content %}
         {% block related_content %}
-        {% include "includes/related_content.html" %}
+        {% include "includes/default_related_content.html" %}
         {% endblock related_content %}
           </div>
          </div>

--- a/postcode_lookup/templates/includes/default_related_content.html
+++ b/postcode_lookup/templates/includes/default_related_content.html
@@ -1,0 +1,45 @@
+<section class="views-element-container" id="block-electoralcommission-views-block-related-content-taxonomy-related-2" aria-labelledby="block-electoralcommission-views-block-related-content-taxonomy-related-2-title">
+    <div class="o-container__padding">
+
+        <h2 id="block-electoralcommission-views-block-related-content-taxonomy-related-2-title">{% trans %}Related content{% endtrans %}</h2>
+
+        <div>
+            <div class="js-view-dom-id-acc178f2bd619faed56de3856cb485835e35b28a3820021585d2a1a943ef8141">
+                <div class="l-grid horizontal l-grid--4-col l-grid--w-v-gutter">
+
+                    {% with
+                        related_title = _("Register to vote"),
+                        related_url=_("/i-am-a/voter/register-vote-and-update-your-details"),
+                        related_description=_("All you need to register to vote is 5 minutes and your National Insurance number. Make sure you register to vote before the deadline for the elections in May.")
+                            %}
+                        {% include "includes/single_related_content.html" %}
+                    {% endwith %}
+
+                    {% with
+                        related_title = _("Apply to vote by post"),
+                        related_url=_("/i-am-a/voter/apply-vote-post"),
+                        related_description=_("Can't get to the polling station on polling day? Apply to vote by post by downloading and completing the application form.")
+                            %}
+                        {% include "includes/single_related_content.html" %}
+                    {% endwith %}
+
+                    {% with
+                        related_title = _("Apply to vote by proxy"),
+                        related_url=_("/i-am-a/voter/apply-vote-proxy"),
+                        related_description=_("Can't get to the polling station on polling day? Ask a trusted person to vote on your behalf and apply for a proxy vote.")
+                            %}
+                        {% include "includes/single_related_content.html" %}
+                    {% endwith %}
+
+                    {% with
+                        related_title = _("Voter ID requirement"),
+                        related_url=_("/i-am-a/voter/voter-id"),
+                        related_description=_("From 4 May 2023, voters in England will need to show photo ID to vote at polling stations in some elections.")
+                            %}
+                        {% include "includes/single_related_content.html" %}
+                    {% endwith %}
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/postcode_lookup/templates/includes/default_related_content.html
+++ b/postcode_lookup/templates/includes/default_related_content.html
@@ -7,14 +7,17 @@
             <div class="js-view-dom-id-acc178f2bd619faed56de3856cb485835e35b28a3820021585d2a1a943ef8141">
                 <div class="l-grid horizontal l-grid--4-col l-grid--w-v-gutter">
 
-                    {% for link in links %}
-                      {% with
-                          related_title=link.title,
-                          related_url=link.url,
-                          related_description=link.description
-                      %}
-                          {% include "includes/single_related_content.html" %}
-                      {% endwith %}
+                    {% for url in [
+                        "/i-am-a/voter/register-vote-and-update-your-details",
+                        "/i-am-a/voter/apply-vote-post",
+                        "/i-am-a/voter/apply-vote-proxy",
+                        "/i-am-a/voter/voter-id",
+                    ] %}
+                        {% with page = get_page_metadata(url, request.current_language) %}
+                            {% with related_title = page.title, related_url = page.url, related_description = page.description %}
+                                {% include "includes/single_related_content.html" %}
+                            {% endwith %}
+                        {% endwith %}
                     {% endfor %}
                 </div>
             </div>

--- a/postcode_lookup/templates/includes/related_content.html
+++ b/postcode_lookup/templates/includes/related_content.html
@@ -7,37 +7,15 @@
             <div class="js-view-dom-id-acc178f2bd619faed56de3856cb485835e35b28a3820021585d2a1a943ef8141">
                 <div class="l-grid horizontal l-grid--4-col l-grid--w-v-gutter">
 
-                    {% with
-                        related_title = _("Register to vote"),
-                        related_url=_("/i-am-a/voter/register-vote-and-update-your-details"),
-                        related_description=_("All you need to register to vote is 5 minutes and your National Insurance number. Make sure you register to vote before the deadline for the elections in May.")
-                            %}
-                        {% include "includes/single_related_content.html" %}
-                    {% endwith %}
-
-                    {% with
-                        related_title = _("Apply to vote by post"),
-                        related_url=_("/i-am-a/voter/apply-vote-post"),
-                        related_description=_("Can't get to the polling station on polling day? Apply to vote by post by downloading and completing the application form.")
-                            %}
-                        {% include "includes/single_related_content.html" %}
-                    {% endwith %}
-
-                    {% with
-                        related_title = _("Apply to vote by proxy"),
-                        related_url=_("/i-am-a/voter/apply-vote-proxy"),
-                        related_description=_("Can't get to the polling station on polling day? Ask a trusted person to vote on your behalf and apply for a proxy vote.")
-                            %}
-                        {% include "includes/single_related_content.html" %}
-                    {% endwith %}
-
-                    {% with
-                        related_title = _("Voter ID requirement"),
-                        related_url=_("/i-am-a/voter/voter-id"),
-                        related_description=_("From 4 May 2023, voters in England will need to show photo ID to vote at polling stations in some elections.")
-                            %}
-                        {% include "includes/single_related_content.html" %}
-                    {% endwith %}
+                    {% for link in links %}
+                      {% with
+                          related_title=link.0,
+                          related_url=link.1,
+                          related_description=""
+                      %}
+                          {% include "includes/single_related_content.html" %}
+                      {% endwith %}
+                    {% endfor %}
                 </div>
             </div>
         </div>

--- a/postcode_lookup/templates/results.html
+++ b/postcode_lookup/templates/results.html
@@ -51,6 +51,13 @@
         {% include 'includes/contact_details.html' %}
 
         {% include 'includes/feedback_section.html' %}
-
     </div>
 {% endblock %}
+
+
+{% block related_content %}
+  {% with links=template_sorter.related_content %}
+    {% include "includes/related_content.html" %}
+  {% endwith %}
+{% endblock related_content %}
+

--- a/postcode_lookup/utils.py
+++ b/postcode_lookup/utils.py
@@ -10,6 +10,7 @@ from dateutil.parser import parse
 from jinja2 import ChainableUndefined
 from jinja2.filters import do_mark_safe
 from markupsafe import Markup, escape
+from related_content import get_page_metadata
 from response_builder.v1.models.base import (
     Ballot,
     CancellationReason,
@@ -288,6 +289,7 @@ def create_templates(locale: str) -> Jinja2Templates:
     env.filters["ballot_cancellation_suffix"] = ballot_cancellation_suffix
 
     env.globals["translated_url"] = translated_url
+    env.globals["get_page_metadata"] = get_page_metadata
     env.globals["additional_ballot_link"] = additional_ballot_link
     env.globals["candidates_groupby_party_list"] = candidates_groupby_party_list
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dev = [
     "freezegun==1.5.5",
     "playwright==1.55.0",
     "beautifulsoup4==4.12.3",
-    "rnet>=2.2.15",
+    "wreq==0.12.0",
     "pytest-subtests==0.14.2",
 ]
 

--- a/tests/test_related_content.py
+++ b/tests/test_related_content.py
@@ -1,0 +1,107 @@
+from types import SimpleNamespace
+
+from related_content import get_related_content
+
+
+def make_ballot(ballot_paper_id):
+    return SimpleNamespace(ballot_paper_id=ballot_paper_id)
+
+
+def make_date(*ballot_paper_ids):
+    return SimpleNamespace(ballots=[make_ballot(b) for b in ballot_paper_ids])
+
+
+def test_two_links_always_present():
+    assert len(get_related_content([], language="en")) == 2
+    assert len(get_related_content([], language="cy")) == 2
+
+
+def test_mayor_london_returns_gla_content():
+    dates = [make_date("mayor.london.2026-05-07")]
+    result = get_related_content(dates, language="en")
+    titles = [title for title, _ in result]
+    assert "Mayor of London and London Assembly" in titles
+    assert "Mayoral elections" not in titles
+
+
+def test_mayor_elsewhere_returns_mayoral_content():
+    dates = [make_date("mayor.tower-hamlets.2026-05-07")]
+    result = get_related_content(dates, language="en")
+    titles = [title for title, _ in result]
+    assert "Mayoral elections" in titles
+    assert "Mayor of London and London Assembly" not in titles
+
+
+def test_parl_by_election():
+    dates = [make_date("parl.sheffield-central.by.2026-05-07")]
+    result = get_related_content(dates, language="en")
+    titles = [title for title, _ in result]
+    assert "UK parliamentary by-elections" in titles
+    assert "UK Parliament" not in titles
+
+
+def test_local_by_election():
+    dates = [make_date("local.tower-hamlets.by.2026-05-07")]
+    result = get_related_content(dates, language="en")
+    titles = [title for title, _ in result]
+    assert "Local council by-elections" in titles
+    assert "Local councils" not in titles
+
+
+def test_unknown_election_type_does_not_raise():
+    dates = [make_date("ref.some-area.2026-05-07")]
+    result = get_related_content(dates, language="en")
+    # only the 2 always-shown links
+    assert len(result) == 2
+
+
+def test_never_more_than_4_items_inner_break():
+    """
+    Single date with many ballots of different types exercises the inner
+    (ballot-level) break: once 2 election-specific links are collected,
+    remaining ballots on the same date are skipped.
+    """
+    dates = [
+        make_date(
+            "parl.stratford-and-bow.by.2026-05-07",
+            "mayor.tower-hamlets.2026-05-07",
+            "gla.c.city-and-east.2026-05-07",
+            "gla.a.2026-05-07",
+            "local.tower-hamlets.bow-east.2026-05-07",
+        )
+    ]
+    result = get_related_content(dates, language="en")
+    assert len(result) == 4
+
+
+def test_never_more_than_4_items_outer_break():
+    """
+    Multiple dates, each with a single ballot, exercises the outer
+    (date-level) break: once 2 election-specific links are collected
+    across dates, remaining dates are skipped.
+    """
+    dates = [
+        make_date("parl.stratford-and-bow.by.2026-05-07"),
+        make_date("mayor.tower-hamlets.2026-05-08"),
+        make_date("gla.c.city-and-east.2026-05-09", "gla.a.2026-05-07"),
+        make_date("local.tower-hamlets.bow-east.2026-05-10"),
+    ]
+    result = get_related_content(dates, language="en")
+    assert len(result) == 4
+
+
+def test_duplicate_ballot_type_not_added_twice():
+    """
+    Multiple ballots of the same election type should only produce
+    one related content link, not a duplicate.
+    """
+    dates = [
+        make_date(
+            "gla.c.city-and-east.2026-05-07",
+            "gla.a.2026-05-07",
+        )
+    ]
+    result = get_related_content(dates, language="en")
+    titles = [title for title, _ in result]
+    assert titles.count("Mayor of London and London Assembly") == 1
+    assert len(result) == 3  # 1 election-specific + 2 always-shown

--- a/tests/test_related_content.py
+++ b/tests/test_related_content.py
@@ -1,0 +1,86 @@
+from types import SimpleNamespace
+
+from related_content import get_related_content
+
+
+def make_ballot(ballot_paper_id):
+    return SimpleNamespace(ballot_paper_id=ballot_paper_id)
+
+
+def make_date(*ballot_paper_ids):
+    return SimpleNamespace(ballots=[make_ballot(b) for b in ballot_paper_ids])
+
+
+def test_two_links_always_present():
+    assert len(get_related_content([], language="en")) == 2
+    assert len(get_related_content([], language="cy")) == 2
+
+
+def test_mayor_london_returns_gla_content():
+    dates = [make_date("mayor.london.2026-05-07")]
+    result = get_related_content(dates, language="en")
+    titles = [r["title"] for r in result]
+    assert "Mayor of London and London Assembly" in titles
+    assert "Voting in mayoral elections" not in titles
+
+
+def test_mayor_elsewhere_returns_mayoral_content():
+    dates = [make_date("mayor.tower-hamlets.2026-05-07")]
+    result = get_related_content(dates, language="en")
+    titles = [r["title"] for r in result]
+    assert "Voting in mayoral elections" in titles
+    assert "Mayor of London and London Assembly" not in titles
+
+
+def test_parl_by_election():
+    dates = [make_date("parl.sheffield-central.by.2026-05-07")]
+    result = get_related_content(dates, language="en")
+    titles = [r["title"] for r in result]
+    assert "UK parliamentary by-elections" in titles
+    assert "UK Parliament" not in titles
+
+
+def test_local_by_election():
+    dates = [make_date("local.tower-hamlets.by.2026-05-07")]
+    result = get_related_content(dates, language="en")
+    titles = [r["title"] for r in result]
+    assert "Local council by-elections" in titles
+    assert "Local councils" not in titles
+
+
+def test_unknown_election_type_does_not_raise():
+    dates = [make_date("ref.some-area.2026-05-07")]
+    result = get_related_content(dates, language="en")
+    # only the 2 default links
+    assert len(result) == 2
+
+
+def test_never_more_than_4_items():
+    dates = [
+        make_date(
+            "parl.stratford-and-bow.by.2026-05-07",
+            "mayor.tower-hamlets.2026-05-07",
+            "gla.c.city-and-east.2026-05-07",
+            "gla.a.2026-05-07",
+            "local.tower-hamlets.bow-east.2026-05-07",
+        )
+    ]
+    result = get_related_content(dates, language="en")
+    assert len(result) == 4
+
+
+def test_duplicate_ballot_type_not_added_twice():
+    """
+    Multiple ballots of the same election type should only produce
+    one related content link, not a duplicate.
+    """
+    dates = [
+        make_date(
+            "gla.c.city-and-east.2026-05-07",
+            "gla.a.2026-05-07",
+        )
+    ]
+    result = get_related_content(dates, language="en")
+    titles = [r["title"] for r in result]
+    assert titles.count("Mayor of London and London Assembly") == 1
+    assert len(result) == 3  # 1 election-specific + 2 default

--- a/uv.lock
+++ b/uv.lock
@@ -219,9 +219,9 @@ dev = [
     { name = "pytest-playwright" },
     { name = "pytest-subtests" },
     { name = "respx" },
-    { name = "rnet" },
     { name = "ruff" },
     { name = "uvicorn" },
+    { name = "wreq" },
 ]
 
 [package.metadata]
@@ -254,9 +254,9 @@ dev = [
     { name = "pytest-playwright", specifier = "==0.8.0" },
     { name = "pytest-subtests", specifier = "==0.14.2" },
     { name = "respx", specifier = "==0.22.0" },
-    { name = "rnet", specifier = ">=2.2.15" },
     { name = "ruff", specifier = "==0.4.10" },
     { name = "uvicorn", specifier = "==0.34.0" },
+    { name = "wreq", specifier = "==0.12.0" },
 ]
 
 [[package]]
@@ -872,27 +872,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rnet"
-version = "2.4.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/10/bc/e5e4395e67803405900b98d503a23c1125432a5a73d2c311dd2ebe11b7fc/rnet-2.4.2.tar.gz", hash = "sha256:9fc9ea17a7afea799e10670f0c1da939f500c440760aeefe42209644ffef5bf5", size = 515573, upload-time = "2025-08-02T23:26:27.795Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/22/434a9aa0228a4fa2abe48b04d36214f5cbe08af45afdb833ac7cc02cd913/rnet-2.4.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b853a9809588a569011142b9bae142ad982387640edcfd38fba4337b044900ae", size = 3694856, upload-time = "2025-08-02T23:25:27.818Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/ca/b49c2dce89381b7697ccb771a6850eea13934ef1eb37a8ef2ba27d925643/rnet-2.4.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:da547d7be92261ead4bc0ce23e30823c760d638055fd301da18c6521ec245fc8", size = 3420543, upload-time = "2025-08-02T23:25:14.783Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/cb/7c5979932069c9f40651d4aca487bfe639a94098eb123d7ec466f7f7730d/rnet-2.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc5bf17b3ed46455fe70a784dff0ccc7beaf54984d554536e644b6d1dacea63e", size = 3658152, upload-time = "2025-08-02T23:25:01.876Z" },
-    { url = "https://files.pythonhosted.org/packages/62/2f/83b754b1383a8cf6e696cb547e0ec4d47ba58dc838b16341be6f1af0ede6/rnet-2.4.2-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:3fe4531b0bffc26d10e3baec2f3d0deb59fb8ff157c56b985d9bd2d6060b2715", size = 3602597, upload-time = "2025-08-02T23:24:24.421Z" },
-    { url = "https://files.pythonhosted.org/packages/91/4a/3012990ec2f309baf41f70929bac0f166db3a7ce5a6bca1143ba6e9b4610/rnet-2.4.2-cp312-cp312-manylinux_2_34_armv7l.whl", hash = "sha256:c51cc5648efdc97bb17d88aab30f0596924766dc137109865bff72539141a81e", size = 3418020, upload-time = "2025-08-02T23:24:36.835Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/5b/6780b490a7d9dfc76c17c68f84b9d5cfb602bdc5db4ca5774930e7b7933e/rnet-2.4.2-cp312-cp312-manylinux_2_34_i686.whl", hash = "sha256:b13ee78075389050ae537d9c6957d8de820d0c7f3c7053dfc3e103e0538890a7", size = 3679644, upload-time = "2025-08-02T23:24:49.07Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/d4/a092274c9513d67f802cc6f3472068f6cbf30652d00d4b5c29617c20479d/rnet-2.4.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1d2e21ed40fcaead89a9f711354f92d5d2690e621a0a6f37edf6d655d1994d58", size = 3953384, upload-time = "2025-08-02T23:25:40.244Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/5f/e4660f38921f41ab2199228d173d6f5d881f391c7b686695dd383fd41693/rnet-2.4.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:8c5672ff8cdb9042a275187badd28279f979e20dcf175da22fce666af7b1b273", size = 3913721, upload-time = "2025-08-02T23:25:52.214Z" },
-    { url = "https://files.pythonhosted.org/packages/44/89/1e81dd97c9ab45bfed871b5cb7fec50893f1a6be6bfd2c237cf3b902cf63/rnet-2.4.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:82037372e94fd7bc999ccac1b971da1a0f15a469979777c11dd225fddb249de1", size = 4001858, upload-time = "2025-08-02T23:26:05.506Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/5c/475c7c9bff6e94a7e5d457e8de2b5786a1f1a7488ad48b29cafddbb530bf/rnet-2.4.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:582f71311cb42db9a396bb95f39577fc4ac5e94d6de17696d2900a05814e5ac6", size = 4162005, upload-time = "2025-08-02T23:26:17.797Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/36/c4bdcdcdd9682fcb1fe01a371e8c25bff949bd719fd78021112538951bd3/rnet-2.4.2-cp312-cp312-win32.whl", hash = "sha256:355b849b67b131fbeffb7b5ee9a4057d3b4f576c1c63a59698a49f86c3a0bc80", size = 3200189, upload-time = "2025-08-02T23:26:56.208Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/cd/cb6f11f33e0a7d567b980c2b7e19f5f0e827a9ea33c53c2de350ef23f121/rnet-2.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:d47a3fb6339e62b06cabeed8dc4aab28050cadc02a8dcbf56b688fb1ca2c7171", size = 3560606, upload-time = "2025-08-02T23:26:43.797Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/70/5ded6c684343fd1a59e5b9ed4ffc7ec783d080bac32ba98c503d363914c0/rnet-2.4.2-cp312-cp312-win_arm64.whl", hash = "sha256:71d3f845b0f44d2353133ac8ee3bea39d00a6766356aa0d1f545b739380d0bea", size = 3199395, upload-time = "2025-08-02T23:26:31.975Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.4.10"
 source = { registry = "https://pypi.org/simple" }
@@ -1102,4 +1081,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/30/6b0809f4510673dc723187aeaf24c7f5459922d01e2f794277a3dfb90345/wcwidth-0.2.14.tar.gz", hash = "sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605", size = 102293, upload-time = "2025-09-22T16:29:53.023Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/b5/123f13c975e9f27ab9c0770f514345bd406d0e8d3b7a0723af9d43f710af/wcwidth-0.2.14-py2.py3-none-any.whl", hash = "sha256:a7bb560c8aee30f9957e5f9895805edd20602f2d7f720186dfd906e82b4982e1", size = 37286, upload-time = "2025-09-22T16:29:51.641Z" },
+]
+
+[[package]]
+name = "wreq"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/0b/aae5482bda449488ba7477204a3d09cd5dc79754da81a9c7a3ea790c22e3/wreq-0.12.0.tar.gz", hash = "sha256:66ec6aa9b67264ea680606fa826ccdb1fbe85366a71d47f5d4325b74eee185c9", size = 252847, upload-time = "2026-06-04T15:53:04.145Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/c1/1adb13c7e5cbb52fdc21570eada5995a3e94aa1d0c9cb227aeda34bd5fd9/wreq-0.12.0-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:3ffb8454b6d27707354e95d57577cf63f7132e7d3af63675b82510e375d8bfa6", size = 4133082, upload-time = "2026-06-04T15:53:43.076Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2a/99c142d3393213a775536238a1b7baec14b339690b78017655d2c38e8fd7/wreq-0.12.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:6c08632e1706d191ba3cb6194abe06256a99c094fade450f2370352d06ee501e", size = 3900301, upload-time = "2026-06-04T15:52:59.918Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b1/aacc3eb58e8ceee9f86cc097a6a077909b5989ccb95aa3ac877cbdbf7a43/wreq-0.12.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67fc6b7fd146e1c3b8e1b9c571fd03535509ec3bf9d1f983abd064a53250c7b9", size = 4387057, upload-time = "2026-06-04T15:53:36.58Z" },
+    { url = "https://files.pythonhosted.org/packages/18/88/901c400f55ab269861430667b47d77a8096f03d88ae248d54e25060805c1/wreq-0.12.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:35bc7899a3f574d4c6c1474eb14cb08b267ba14e7bc3dab69283ca54f6818b61", size = 4355263, upload-time = "2026-06-04T15:52:49.761Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/56/9e93c9bec124178e4b5fb83a6543cc0a137665d8eb36bb17f3f2060285b0/wreq-0.12.0-cp311-abi3-manylinux_2_34_armv7l.whl", hash = "sha256:6ffef38693997f8bb353f60916ff50ad1c68a4ac75d33316f0ce84afbcdce682", size = 4047326, upload-time = "2026-06-04T15:53:01.377Z" },
+    { url = "https://files.pythonhosted.org/packages/88/65/9ca12f6be5153cc91c80e3e2a8067c3a6563aff1c81d17efdf830af74885/wreq-0.12.0-cp311-abi3-manylinux_2_38_i686.whl", hash = "sha256:26f0dbce482d246091f28ef753059aaba1e4c6653b5ef712746207581193dd89", size = 4520220, upload-time = "2026-06-04T15:52:53.29Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/3b/f2a9b1866bbbb4eeaee41df05c52623a5ad9c9bbee3ed7923bd1bd0467e4/wreq-0.12.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ea89631cb51d0f93c8411dad0c824fc188d09e4bcd2a4c1056b02630fdafd533", size = 3964737, upload-time = "2026-06-04T15:53:20.216Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d6/8f3d130a9f0de3814194aa56eede5a8ca80b6a7f310711e4ae4d42987cd2/wreq-0.12.0-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:7770678e2af86ced5a58c4ab2fe981f75171a09ecf733445e680e69e7a56cc09", size = 3792218, upload-time = "2026-06-04T15:53:08.607Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/c6/720530f508be3d2dd6e3cde6e751397d975245d12dcf3cb305097d4b21fd/wreq-0.12.0-cp311-abi3-musllinux_1_2_i686.whl", hash = "sha256:ca67dfa9b4216d9eeaa428c887c5169b5c3a9f502fa737b2a36e219c81da2a56", size = 4068041, upload-time = "2026-06-04T15:52:44.407Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/4c/200e1b6db1b6298f3350807b1e27e7f0b1a5b85ed53fef80bb42669a8aab/wreq-0.12.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:99ba68deebef71582e7eb7b4d7ebef78e3a0a719e3a7c6e22e04d271d8a35b65", size = 4198426, upload-time = "2026-06-04T15:52:40.631Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/37/2092cf6d19f77fd3f2c7957e5cdac06bab947af9ebbd7eca3b5c8311f376/wreq-0.12.0-cp311-abi3-win32.whl", hash = "sha256:a610d883697011f722de4b24a3ff9d566e86adba91cb4b76cf83714ef7996078", size = 3846024, upload-time = "2026-06-04T15:53:13.484Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/45/092cfc1aa00c1ef2e63026d6da9f4e7bdffdf41267c1500399384ff114f9/wreq-0.12.0-cp311-abi3-win_amd64.whl", hash = "sha256:a349f93237f29061d4b46e092e4b4f70e9607b5a8de8f9b4493a1236ff4ae869", size = 4191798, upload-time = "2026-06-04T15:53:38.359Z" },
+    { url = "https://files.pythonhosted.org/packages/18/44/111647fc162cc46ba17e2c76bf178f88ea3e78b1b7d291f38a250cd343c1/wreq-0.12.0-cp311-abi3-win_arm64.whl", hash = "sha256:f000383ec719cf8583b7df90c9445cd75522756e1ced61e622f9edc142de3288", size = 3843406, upload-time = "2026-06-04T15:53:18.424Z" },
+    { url = "https://files.pythonhosted.org/packages/34/cb/6537e4bd8144c1af98e6293c9b2a0dfeeb5784f21aee438c1821139806b0/wreq-0.12.0-cp314-abi3-android_24_arm64_v8a.whl", hash = "sha256:d4755a840f20e22cae6d037003850fc29e293941dfeffd37095209037d09de0e", size = 4027983, upload-time = "2026-06-04T15:52:46.219Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/4f/7b06bb455d62782d10bcce2ac5491da1dd468b555c5d0d7978a6f6a1445e/wreq-0.12.0-cp314-abi3-android_24_x86_64.whl", hash = "sha256:d85c107fa87878e0730199f87c15c129d5d1d63ae34f6e3e18c14974e5284438", size = 4168944, upload-time = "2026-06-04T15:53:39.915Z" },
 ]


### PR DESCRIPTION
This PR is a first bash at implementing the EC's desired changes to the related content section.

There are still some details to be worked out both in terms of both the requirements and the implementation details, but I think what's here is worth looking at.

Also, we might want to block merging this on some other changes. I think they want to move some of the stuff that is currently in "related content" into the body of the page so it might not make sense to merge this until we have done those changes first