### PR TITLE
upgrade to starlette 1.x

### DIFF
--- a/postcode_lookup/utils.py
+++ b/postcode_lookup/utils.py
@@ -1,6 +1,4 @@
 import datetime as dt
-import typing
-from os import PathLike
 from pathlib import Path
 from typing import Any, List
 
@@ -273,51 +271,38 @@ def is_uncontested(cancellation_reason: CancellationReason) -> bool:
     return cancellation_reason == CancellationReason.EQUAL_CANDIDATES
 
 
-class _i18nJinja2Templates(Jinja2Templates):
-    locale = None
+def create_templates(locale: str) -> Jinja2Templates:
+    root = Path(__file__).parent
 
-    def _create_env(
-        self, directory: typing.Union[str, PathLike], **env_options: typing.Any
-    ) -> jinja2.Environment:
-        env_options["extensions"] = [
-            "jinja2.ext.i18n",
-        ]
-        env_options["undefined"] = ChainableUndefined
-        env = super()._create_env(directory, **env_options)
-        env.filters["date_filter"] = date_format
-        env.filters["apnumber"] = apnumber
-        env.filters["pluralize"] = pluralize
-        env.filters["nl2br"] = nl2br
-        env.filters["time_filter"] = time_format
-        env.policies["ext.i18n.trimmed"] = True
-        env.globals["translated_url"] = translated_url
-        env.globals["additional_ballot_link"] = additional_ballot_link
-        env.globals["candidates_groupby_party_list"] = (
-            candidates_groupby_party_list
-        )
-        env.filters["ballot_cancellation_suffix"] = ballot_cancellation_suffix
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(root / "templates"),
+        extensions=["jinja2.ext.i18n"],
+        undefined=ChainableUndefined,
+    )
 
-        locale_dir = Path(__file__).parent / "locale"
-        list_of_desired_locales = [self.locale]
+    env.filters["date_filter"] = date_format
+    env.filters["apnumber"] = apnumber
+    env.filters["pluralize"] = pluralize
+    env.filters["nl2br"] = nl2br
+    env.filters["time_filter"] = time_format
+    env.filters["ballot_cancellation_suffix"] = ballot_cancellation_suffix
 
-        translations = Translations.load(locale_dir, list_of_desired_locales)
+    env.globals["translated_url"] = translated_url
+    env.globals["additional_ballot_link"] = additional_ballot_link
+    env.globals["candidates_groupby_party_list"] = candidates_groupby_party_list
 
-        env.install_gettext_translations(translations)
+    env.policies["ext.i18n.trimmed"] = True
 
-        return env
+    locale_dir = root / "locale"
+    translations = Translations.load(locale_dir, [locale])
+
+    env.install_gettext_translations(translations)
+
+    return Jinja2Templates(env=env)
 
 
-class en_i18nJinja2Templates(_i18nJinja2Templates):
-    locale = "en"
-
-
-class cy_i18nJinja2Templates(_i18nJinja2Templates):
-    locale = "cy"
-
-
-root = Path(__file__).parent
-en_templates = en_i18nJinja2Templates(directory=root / "templates")
-cy_templates = cy_i18nJinja2Templates(directory=root / "templates")
+en_templates = create_templates("en")
+cy_templates = create_templates("cy")
 
 
 class i18nMiddleware:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "mangum==0.19.0",
     "sentry-sdk[starlette]==2.21.0",
     "starlette-babel==1.0.3",
-    "starlette==0.49.1",
+    "starlette==1.2.1",
     "uk-election-timetables==4.4.0",
     "dc-response-builder",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -233,7 +233,7 @@ requires-dist = [
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "mangum", specifier = "==0.19.0" },
     { name = "sentry-sdk", extras = ["starlette"], specifier = "==2.21.0" },
-    { name = "starlette", specifier = "==0.49.1" },
+    { name = "starlette", specifier = "==1.2.1" },
     { name = "starlette-babel", specifier = "==1.0.3" },
     { name = "uk-election-timetables", specifier = "==4.4.0" },
 ]
@@ -967,15 +967,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.49.1"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/3f/507c21db33b66fb027a332f2cb3abbbe924cc3a79ced12f01ed8645955c9/starlette-0.49.1.tar.gz", hash = "sha256:481a43b71e24ed8c43b11ea02f5353d77840e01480881b8cb5a26b8cae64a8cb", size = 2654703, upload-time = "2025-10-28T17:34:10.928Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/da/545b75d420bb23b5d494b0517757b351963e974e79933f01e05c929f20a6/starlette-0.49.1-py3-none-any.whl", hash = "sha256:d92ce9f07e4a3caa3ac13a79523bd18e3bc0042bb8ff2d759a8e7dd0e1859875", size = 74175, upload-time = "2025-10-28T17:34:09.13Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This is actually not too much of a heavy lift.
As far as I can tell, the only thing we need to deal with is a change in how we inject options into the jinja environment.

https://starlette.dev/release-notes/#:~:text=Remove%20**env_options%20parameter%20from%20Jinja2Templates.%20Use%20a%20preconfigured%20jinja2.Environment%20via%20the%20env%20parameter%20instead%20%233118.